### PR TITLE
Add function to create a dictionary from a sequence

### DIFF
--- a/Source/Public/Dictionary.swift
+++ b/Source/Public/Dictionary.swift
@@ -1,0 +1,58 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension Dictionary {
+    
+    /// Creates a dictionary by applying a function over a sequence, and assigning the calculated value to the sequence element. Also maps the keys
+    public init<T, S: Sequence>(_ sequence: S, keyMapping: (T) -> Key, valueMapping: (T) -> Value) where S.Iterator.Element == T {
+        
+        self.init()
+        
+        for key in sequence {
+            let newKey = keyMapping(key)
+            let value = valueMapping(key)
+            self[newKey] = value
+        }
+    }
+    
+    /// Maps the key keeping the association with values
+    public func mapKeys<T: Hashable>(_ transform: (Key) -> T) -> [T: Value] {
+        var mapping : [T : Value] = [:]
+        for (key, value) in self {
+            mapping[transform(key)] = value
+        }
+        return mapping
+        
+    }
+}
+
+extension Sequence {
+    
+    /// Returns a dictionary created by key-value association as returned by the transform function.
+    /// Multiple values with the same key will be overwritten by the last element of the sequence to return that key
+    public func dictionary<K : Hashable, V>(_ transform: (Self.Iterator.Element) throws -> (key: K, value: V)) rethrows -> [K : V] {
+        var mapping : [K : V] = [:]
+        for value in self {
+            let keyValue = try transform(value)
+            mapping[keyValue.key] = keyValue.value
+        }
+        return mapping
+    }
+}

--- a/Source/Public/Sets.swift
+++ b/Source/Public/Sets.swift
@@ -74,29 +74,3 @@ extension NSSet {
         }
     }
 }
-
-// MARK: Dictionary
-extension Dictionary {
-    
-    /// Creates a dictionary by applying a function over a sequence, and assigning the calculated value to the sequence element. Also maps the keys
-    init<T, S: Sequence>(_ sequence: S, keyMapping: (T) -> Key, valueMapping: (T) -> Value) where S.Iterator.Element == T {
-        
-        self.init()
-        
-        for key in sequence {
-            let newKey = keyMapping(key)
-            let value = valueMapping(key)
-            self[newKey] = value
-        }
-    }
-
-    /// Maps the key keeping the association with values
-    func mapKeys<T: Hashable>(_ transform: (Key) -> T) -> [T: Value] {
-        var mapping : [T : Value] = [:]
-        for (key, value) in self {
-            mapping[transform(key)] = value
-        }
-        return mapping
-        
-    }
-}

--- a/Tests/DictionaryTests.swift
+++ b/Tests/DictionaryTests.swift
@@ -1,0 +1,82 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import XCTest
+import ZMUtilities
+
+class DictionaryTests : XCTestCase {
+    
+    func testThatItMapsKeys() {
+        
+        // GIVEN
+        let input = ["A" : 12, "Boo" : 23]
+        
+        // WHEN
+        let output = input.mapKeys {
+            return $0.lowercased()
+        }
+        
+        // THEN
+        XCTAssertEqual(output, ["a": 12, "boo" : 23])
+    }
+    
+    func testThatItMapsKeysWithEmptyDictionary() {
+        
+        // GIVEN
+        let input = [String:Int]()
+        
+        // WHEN
+        let output = input.mapKeys {
+            return $0.lowercased()
+        }
+        
+        // THEN
+        XCTAssertEqual(output, [:])
+    }
+    
+    func testThatItCreatesDictionaryFromCollection() {
+        
+        // GIVEN
+        let input = ["a", "bbb", "cc"]
+        
+        // WHEN
+        let output = input.dictionary {
+            return (key: $0, value: $0.utf8.count)
+        }
+        
+        // THEN
+        XCTAssertEqual(output, ["a" : 1, "bbb" : 3, "cc" : 2])
+    }
+    
+    func testThatItOverwriteKeysIfRepeated() {
+        
+        // GIVEN
+        let input = ["a", "bbb", "a"]
+        
+        // WHEN
+        var count = 0
+        let output = input.dictionary { (value) -> (key: String, value: Int) in
+            count += 1
+            return (key: value, value: count)
+        }
+        
+        // THEN
+        XCTAssertEqual(output, ["a" : 3, "bbb" : 2])
+    }
+}

--- a/ZMUtilities.xcodeproj/project.pbxproj
+++ b/ZMUtilities.xcodeproj/project.pbxproj
@@ -42,6 +42,8 @@
 		3E88BF631B1F68DC00232589 /* NSOperationQueue+Helpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E88BF601B1F68DC00232589 /* NSOperationQueue+Helpers.m */; };
 		3E88BF6B1B1F693F00232589 /* NSData+ZMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E88BF661B1F693F00232589 /* NSData+ZMAdditions.m */; };
 		3E88BF6F1B1F693F00232589 /* NSDate+Utility.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E88BF681B1F693F00232589 /* NSDate+Utility.m */; };
+		54024FE61DF81C8E009BF6A0 /* Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54024FE51DF81C8E009BF6A0 /* Dictionary.swift */; };
+		54024FE81DF81CC6009BF6A0 /* DictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54024FE71DF81CC6009BF6A0 /* DictionaryTests.swift */; };
 		543B049E1BC6B5FA008C2912 /* NSData+ZMSCrypto.h in Headers */ = {isa = PBXBuildFile; fileRef = 543B049C1BC6B5FA008C2912 /* NSData+ZMSCrypto.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		543B04A11BC6B693008C2912 /* NSData+ZMSCrypto.m in Sources */ = {isa = PBXBuildFile; fileRef = 543B04A01BC6B693008C2912 /* NSData+ZMSCrypto.m */; };
 		544B2FFE1C1FF79500384477 /* data_to_hash.enc in Resources */ = {isa = PBXBuildFile; fileRef = 544B2FFC1C1FF2DD00384477 /* data_to_hash.enc */; };
@@ -201,6 +203,8 @@
 		3E88BF601B1F68DC00232589 /* NSOperationQueue+Helpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSOperationQueue+Helpers.m"; sourceTree = "<group>"; };
 		3E88BF661B1F693F00232589 /* NSData+ZMAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSData+ZMAdditions.m"; sourceTree = "<group>"; };
 		3E88BF681B1F693F00232589 /* NSDate+Utility.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDate+Utility.m"; sourceTree = "<group>"; };
+		54024FE51DF81C8E009BF6A0 /* Dictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dictionary.swift; sourceTree = "<group>"; };
+		54024FE71DF81CC6009BF6A0 /* DictionaryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DictionaryTests.swift; sourceTree = "<group>"; };
 		543B049C1BC6B5FA008C2912 /* NSData+ZMSCrypto.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSData+ZMSCrypto.h"; sourceTree = "<group>"; };
 		543B04A01BC6B693008C2912 /* NSData+ZMSCrypto.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSData+ZMSCrypto.m"; sourceTree = "<group>"; };
 		544B2FFC1C1FF2DD00384477 /* data_to_hash.enc */ = {isa = PBXFileReference; lastKnownFileType = file; path = data_to_hash.enc; sourceTree = "<group>"; };
@@ -530,6 +534,7 @@
 				54CA31151B74F36B00B820C0 /* Functional.swift */,
 				BF3A7A5F1D8AA9B30034FF40 /* OptionalComparison.swift */,
 				54CA311E1B74F36B00B820C0 /* Sets.swift */,
+				54024FE51DF81C8E009BF6A0 /* Dictionary.swift */,
 				54CA311F1B74F36B00B820C0 /* SwiftDebugging.swift */,
 				54CA31201B74F36B00B820C0 /* UnownedObject.swift */,
 				54C388A71C4D5A3A00A55C79 /* NSUUID+Type1.swift */,
@@ -591,6 +596,7 @@
 				54C388A91C4D5AF600A55C79 /* NSUUID+Type1Tests.swift */,
 				16EB9B371CE0D7D800883FCF /* NSString+MIMETypeTests.swift */,
 				F9FCE0A41C7DBD180092BA68 /* ZMSwiftExceptionHandlerTests.m */,
+				54024FE71DF81CC6009BF6A0 /* DictionaryTests.swift */,
 			);
 			name = Source;
 			sourceTree = "<group>";
@@ -797,6 +803,7 @@
 				F9C9A7BD1CAEAF240039E10C /* ZMPropertyValidator.m in Sources */,
 				3E88BF6B1B1F693F00232589 /* NSData+ZMAdditions.m in Sources */,
 				54C388A81C4D5A3B00A55C79 /* NSUUID+Type1.swift in Sources */,
+				54024FE61DF81C8E009BF6A0 /* Dictionary.swift in Sources */,
 				54CA313D1B74F36B00B820C0 /* SwiftDebugging.swift in Sources */,
 				F9C9A7AC1CAEACB10039E10C /* ZMEmailAddressValidator.m in Sources */,
 				3E88BE3D1B1F478200232589 /* ZMDebugHelpers.m in Sources */,
@@ -839,6 +846,7 @@
 				F9C9A7C51CAEAFE10039E10C /* ZMAccentColorValidatorTests.m in Sources */,
 				F9C9A7C81CAEAFE10039E10C /* ZMStringLengthValidatorTests.m in Sources */,
 				F9D381DB1B70DF8500E6E4EB /* Hack.swift in Sources */,
+				54024FE81DF81CC6009BF6A0 /* DictionaryTests.swift in Sources */,
 				F9C9A7C71CAEAFE10039E10C /* ZMPhoneNumberValidatorTests.m in Sources */,
 				F9D381AE1B70B93800E6E4EB /* ZMTimerTests.m in Sources */,
 				F9D381B21B70B94B00E6E4EB /* NSSet+ZMUTests.m in Sources */,


### PR DESCRIPTION
# Reason for this pull request
Add function to create a dictionary from a sequence. This is useful in those many places when we want to create a look up table from an array to avoid iterating the entire array to find element by id many times over.

E.g. when fetching a bunch of results from Core Data in a single fetch, then I want to access them by their ID