### PR TITLE
Add extension on String to detect Emoji

### DIFF
--- a/Source/Public/String+Emoji.swift
+++ b/Source/Public/String+Emoji.swift
@@ -1,0 +1,33 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+
+public extension String {
+
+    var containsEmoji: Bool {
+        if #available(iOS 9, *) {
+            return applyingTransform(.toUnicodeName, reverse: false) != self
+        } else {
+            let ref = NSMutableString(string: self) as CFMutableString
+            CFStringTransform(ref, nil, kCFStringTransformToLatin, false)
+            return ref as String != self
+        }
+    }
+
+}

--- a/Tests/String+EmojiTests.swift
+++ b/Tests/String+EmojiTests.swift
@@ -1,0 +1,45 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import XCTest
+
+
+class String_EmojiTests: XCTestCase {
+
+    func testThatItDetectsAnEmoji() {
+        XCTAssertTrue("🍔".containsEmoji)
+    }
+
+    func testThatItDetectsMultipleEmoji() {
+        XCTAssertTrue("🍔😜🌮🎉🍕".containsEmoji)
+    }
+
+    func testThatItDetectsAnEmojiIfItIsContainedInText() {
+        XCTAssertTrue("abcdefghijklmnopqrstuv🎉wxyz_1234567890-=+'\\/`~".containsEmoji)
+    }
+
+    func testThatItDoesNotDetectAnEmojiIfThereIsNone() {
+        XCTAssertFalse(" abcdefghijklmnopqrstuvwxyz_1234567890-=+'\\/`~".containsEmoji)
+    }
+
+    func testThatItDoesNotDetectAnEmojiIfThereIsNone_EmptyString() {
+        XCTAssertFalse("".containsEmoji)
+    }
+
+}

--- a/Tests/String+EmojiTests.swift
+++ b/Tests/String+EmojiTests.swift
@@ -49,4 +49,12 @@ class String_EmojiTests: XCTestCase {
     func testThatNonLatinWithEmojiIsDetectedAsContainingEmoji() {
         XCTAssertTrue("الأشخاص المفضلين🙈".containsEmoji)
     }
+
+    func testThatNonLatinsNotDetectedAsContainingEmoji_Mandarin() {
+        XCTAssertFalse("普通话/普通話".containsEmoji)
+    }
+
+    func testThatNonLatinWithEmojiIsDetectedAsContainingEmoji_Mandarin() {
+        XCTAssertTrue("普通话/普通話🙈".containsEmoji)
+    }
 }

--- a/Tests/String+EmojiTests.swift
+++ b/Tests/String+EmojiTests.swift
@@ -42,4 +42,11 @@ class String_EmojiTests: XCTestCase {
         XCTAssertFalse("".containsEmoji)
     }
 
+    func testThatNonLatinsNotDetectedAsContainingEmoji() {
+        XCTAssertFalse("الأشخاص المفضلين".containsEmoji)
+    }
+
+    func testThatNonLatinWithEmojiIsDetectedAsContainingEmoji() {
+        XCTAssertTrue("الأشخاص المفضلين🙈".containsEmoji)
+    }
 }

--- a/ZMUtilities.xcodeproj/project.pbxproj
+++ b/ZMUtilities.xcodeproj/project.pbxproj
@@ -88,6 +88,8 @@
 		BF4A15CC1D47B8860051E8BA /* enterprise-production.xml in Resources */ = {isa = PBXBuildFile; fileRef = BF4A15CB1D47B8860051E8BA /* enterprise-production.xml */; };
 		BF4A15CE1D47BECC0051E8BA /* appstore-sandbox.xml in Resources */ = {isa = PBXBuildFile; fileRef = BF4A15CD1D47BECC0051E8BA /* appstore-sandbox.xml */; };
 		BF4A15D01D47BF360051E8BA /* enterprise-sandbox.xml in Resources */ = {isa = PBXBuildFile; fileRef = BF4A15CF1D47BF360051E8BA /* enterprise-sandbox.xml */; };
+		BFBAE9DB1E01A8F2003FCE49 /* String+Emoji.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFBAE9DA1E01A8F2003FCE49 /* String+Emoji.swift */; };
+		BFBAE9DD1E01A930003FCE49 /* String+EmojiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFBAE9DC1E01A930003FCE49 /* String+EmojiTests.swift */; };
 		F991CE1D1CB64205004D8465 /* ZMPropertyValidator.h in Headers */ = {isa = PBXBuildFile; fileRef = F991CE1C1CB64205004D8465 /* ZMPropertyValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F9C9A7891CAE9F900039E10C /* NSString+Normalization.h in Headers */ = {isa = PBXBuildFile; fileRef = F9C9A7881CAE9F900039E10C /* NSString+Normalization.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F9C9A78B1CAE9F9A0039E10C /* NSString+Normalization.m in Sources */ = {isa = PBXBuildFile; fileRef = F9C9A78A1CAE9F9A0039E10C /* NSString+Normalization.m */; };
@@ -269,6 +271,8 @@
 		BF4A15CB1D47B8860051E8BA /* enterprise-production.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "enterprise-production.xml"; sourceTree = "<group>"; };
 		BF4A15CD1D47BECC0051E8BA /* appstore-sandbox.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; name = "appstore-sandbox.xml"; path = "../appstore-sandbox.xml"; sourceTree = "<group>"; };
 		BF4A15CF1D47BF360051E8BA /* enterprise-sandbox.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "enterprise-sandbox.xml"; sourceTree = "<group>"; };
+		BFBAE9DA1E01A8F2003FCE49 /* String+Emoji.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Emoji.swift"; sourceTree = "<group>"; };
+		BFBAE9DC1E01A930003FCE49 /* String+EmojiTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+EmojiTests.swift"; sourceTree = "<group>"; };
 		F991CE1C1CB64205004D8465 /* ZMPropertyValidator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZMPropertyValidator.h; sourceTree = "<group>"; };
 		F9C9A7881CAE9F900039E10C /* NSString+Normalization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+Normalization.h"; sourceTree = "<group>"; };
 		F9C9A78A1CAE9F9A0039E10C /* NSString+Normalization.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+Normalization.m"; sourceTree = "<group>"; };
@@ -539,6 +543,7 @@
 				54CA31201B74F36B00B820C0 /* UnownedObject.swift */,
 				54C388A71C4D5A3A00A55C79 /* NSUUID+Type1.swift */,
 				16EB9B351CE0D5A000883FCF /* NSString+MIMEType.swift */,
+				BFBAE9DA1E01A8F2003FCE49 /* String+Emoji.swift */,
 				870FFA811D82B73B007E9806 /* Data+ZMSCrypto.swift */,
 			);
 			path = Public;
@@ -597,6 +602,7 @@
 				16EB9B371CE0D7D800883FCF /* NSString+MIMETypeTests.swift */,
 				F9FCE0A41C7DBD180092BA68 /* ZMSwiftExceptionHandlerTests.m */,
 				54024FE71DF81CC6009BF6A0 /* DictionaryTests.swift */,
+				BFBAE9DC1E01A930003FCE49 /* String+EmojiTests.swift */,
 			);
 			name = Source;
 			sourceTree = "<group>";
@@ -812,6 +818,7 @@
 				54CA313B1B74F36B00B820C0 /* Sets.swift in Sources */,
 				097E36C31B7B62150039CC4C /* NSLocale+Internal.m in Sources */,
 				BF3A7A601D8AA9B30034FF40 /* OptionalComparison.swift in Sources */,
+				BFBAE9DB1E01A8F2003FCE49 /* String+Emoji.swift in Sources */,
 				F9C9A7941CAEA7200039E10C /* ZMEncodedNSUUIDWithTimestamp.m in Sources */,
 				3E88BE231B1F478200232589 /* NSURL+QueryComponents.m in Sources */,
 				3E88BE431B1F478200232589 /* ZMFunctional+noARC.m in Sources */,
@@ -860,6 +867,7 @@
 				F9D381AC1B70B92F00E6E4EB /* NSDate+ZMUTests.m in Sources */,
 				091799761B7E2E4D00E60DD9 /* ZMMobileProvisionParserTests.m in Sources */,
 				F9C9A78E1CAEA0110039E10C /* NSString_NormalizationTests.m in Sources */,
+				BFBAE9DD1E01A930003FCE49 /* String+EmojiTests.swift in Sources */,
 				091799751B7E2E4D00E60DD9 /* ZMDeploymentEnvironmentTests.m in Sources */,
 				871E12351C4FEED200862958 /* UnownedNSObjectTests.swift in Sources */,
 				F9D381B01B70B94300E6E4EB /* ZMFunctionalTests.m in Sources */,


### PR DESCRIPTION
# What's in this PR?

Add an extension on String to check for Emoji, this is needed in order to disallow the input of emoji as username, as a check like
```swift
let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyz_").union(.decimalDigits)
CharacterSet(charactersIn: handle).isSubset(of: allowed)
```
will not catch emoji.