### PR TITLE
Add functions for mapping dictionaries 

### DIFF
--- a/Source/Public/Dictionary.swift
+++ b/Source/Public/Dictionary.swift
@@ -32,6 +32,21 @@ extension Dictionary {
         }
     }
     
+    /// Maps a dictionary's keys and values to a new dictionary applying `keysMapping` to all keys and `valueMapping` 
+    /// If `valueMapping` returns nil, the new dictionary will not contain the corresponding key
+    public func mapKeysAndValues<NewKey, NewValue>(keysMapping: ((Key) -> NewKey),
+                                                   valueMapping: ((Key, Value) -> NewValue?))
+        -> Dictionary<NewKey, NewValue>
+    {
+        var dict = Dictionary<NewKey, NewValue>()
+        for (key, value) in self {
+            if let newValue = valueMapping(key, value) {
+                dict.updateValue(newValue, forKey: keysMapping(key))
+            }
+        }
+        return dict
+    }
+    
     /// Maps the key keeping the association with values
     public func mapKeys<T: Hashable>(_ transform: (Key) -> T) -> [T: Value] {
         var mapping : [T : Value] = [:]
@@ -41,7 +56,27 @@ extension Dictionary {
         return mapping
         
     }
+    
+    /// Creates a dictionary with the given keys and and sets `repeatedValue` as value for all keys
+    public init(keys: [Key], repeatedValue: Value) {
+        self.init()
+        for key in keys {
+            updateValue(repeatedValue, forKey: key)
+        }
+    }
+    
+    /// Joins two dictionaries with each other while overwriting existing values with values in `other`
+    public func updated(other:Dictionary) -> Dictionary {
+        var newDict = self
+        for (key,value) in other {
+            newDict.updateValue(value, forKey:key)
+        }
+        return newDict
+    }
 }
+
+
+
 
 extension Sequence {
     
@@ -55,4 +90,5 @@ extension Sequence {
         }
         return mapping
     }
+    
 }

--- a/Tests/DictionaryTests.swift
+++ b/Tests/DictionaryTests.swift
@@ -79,4 +79,72 @@ class DictionaryTests : XCTestCase {
         // THEN
         XCTAssertEqual(output, ["a" : 3, "bbb" : 2])
     }
+    
+    func testThatItKeepsOptionalValues(){
+        // GIVEN
+        let input = ["a", "b"]
+        
+        // WHEN
+        var count = 0
+        let output : [String : Int?] = input.dictionary { (element) -> (key: String, value: Int?) in
+            count += 1
+            if element == "a" {
+                return (key: element, value: nil)
+            }
+            return (key: element, value: count)
+        }
+        
+        // THEN
+        XCTAssertTrue(output.keys.contains("a"))
+        XCTAssertNil(output["a"]!)
+        XCTAssertTrue(output.keys.contains("b"))
+        XCTAssertNotNil(output["b"]!)
+    }
+    
+    func testThatItCreateDictionaryWithRepeatedValues(){
+        // given
+        let input = [1,2,3]
+        
+        // when
+        let dictionary = Dictionary(keys: input, repeatedValue: "foo")
+        
+        // then
+        XCTAssertEqual(dictionary, [1 : "foo", 2 : "foo", 3 : "foo"])
+    }
+    
+    func testThatItMapsADictionarysKeysAndValues(){
+        // given
+        let input = [1 : "foo1", 2 : "foo2", 3: "foo3"]
+        
+        // when
+        let dictionary : [Int : String] = input.mapKeysAndValues(keysMapping: ({$0*2}), valueMapping: ({$1 + "bar"}))
+        
+        // then
+        XCTAssertEqual(dictionary, [2 : "foo1bar", 4 : "foo2bar", 6 : "foo3bar"])
+    }
+    
+    func testThatItRemovesNilValuesWhenMappingKeysAndValues(){
+        // given
+        let input = [1 : "foo1", 2 : "foo2", 3: "foo3"]
+        
+        // when
+        let dictionary : [Int : String] = input.mapKeysAndValues(keysMapping: ({$0*2}),
+                                                                 valueMapping: ({ $0 == 1 ? nil : $1 + "bar"}))
+        
+        // then
+        XCTAssertEqual(dictionary, [4 : "foo2bar", 6 : "foo3bar"])
+    }
+    
+    func testThatItMergesTwoDictioniesOverwritingOldValue(){
+        // given
+        let input = [1 : "foo1", 2 : "foo2", 3: "foo3"]
+        let other = [1 : "bar", 4: "foo4"]
+        
+        // when
+        let updated = input.updated(other: other)
+        
+        // then
+        XCTAssertEqual(updated, [1 : "bar", 2 : "foo2", 3: "foo3", 4: "foo4"])
+    }
+
 }


### PR DESCRIPTION
Adds three new functions:

1) Mapping a dictionaries keys and values to a new dictionary
2) Initializing a Dictionary with an array of keys and setting the same value for each key
3) Updating and merging a dictionaries values with another dictionary