### PR TITLE
Add NSPredicate compounding operators

### DIFF
--- a/Source/Public/NSPredicateOperators.swift
+++ b/Source/Public/NSPredicateOperators.swift
@@ -17,12 +17,10 @@
 //
 
 
-public func &&(lhs: NSPredicate, rhs: NSPredicate?) -> NSPredicate {
-    guard let rhs = rhs else { return lhs }
+public func &&(lhs: NSPredicate, rhs: NSPredicate) -> NSPredicate {
     return NSCompoundPredicate(andPredicateWithSubpredicates: [lhs, rhs])
 }
 
-public func ||(lhs: NSPredicate, rhs: NSPredicate?) -> NSPredicate {
-    guard let rhs = rhs else { return lhs }
+public func ||(lhs: NSPredicate, rhs: NSPredicate) -> NSPredicate {
     return NSCompoundPredicate(orPredicateWithSubpredicates: [lhs, rhs])
 }

--- a/Source/Public/NSPredicateOperators.swift
+++ b/Source/Public/NSPredicateOperators.swift
@@ -1,0 +1,36 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+public func &&(lhs: NSPredicate, rhs: NSPredicate) -> NSPredicate {
+    return NSCompoundPredicate(andPredicateWithSubpredicates: [lhs, rhs])
+}
+
+public func &&(lhs: NSPredicate, rhs: NSPredicate?) -> NSPredicate {
+    guard let rhs = rhs else { return lhs }
+    return NSCompoundPredicate(andPredicateWithSubpredicates: [lhs, rhs])
+}
+
+public func ||(lhs: NSPredicate, rhs: NSPredicate) -> NSPredicate {
+    return NSCompoundPredicate(orPredicateWithSubpredicates: [lhs, rhs])
+}
+
+public func ||(lhs: NSPredicate, rhs: NSPredicate?) -> NSPredicate {
+    guard let rhs = rhs else { return lhs }
+    return NSCompoundPredicate(orPredicateWithSubpredicates: [lhs, rhs])
+}

--- a/Source/Public/NSPredicateOperators.swift
+++ b/Source/Public/NSPredicateOperators.swift
@@ -17,17 +17,9 @@
 //
 
 
-public func &&(lhs: NSPredicate, rhs: NSPredicate) -> NSPredicate {
-    return NSCompoundPredicate(andPredicateWithSubpredicates: [lhs, rhs])
-}
-
 public func &&(lhs: NSPredicate, rhs: NSPredicate?) -> NSPredicate {
     guard let rhs = rhs else { return lhs }
     return NSCompoundPredicate(andPredicateWithSubpredicates: [lhs, rhs])
-}
-
-public func ||(lhs: NSPredicate, rhs: NSPredicate) -> NSPredicate {
-    return NSCompoundPredicate(orPredicateWithSubpredicates: [lhs, rhs])
 }
 
 public func ||(lhs: NSPredicate, rhs: NSPredicate?) -> NSPredicate {

--- a/Tests/NSPredicateOperatorTests.swift
+++ b/Tests/NSPredicateOperatorTests.swift
@@ -1,0 +1,78 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import Foundation
+import XCTest
+
+
+private class PredicateTestHelper: NSObject {
+    let a: Bool
+    let b: Bool
+
+    init(a: Bool, b: Bool) {
+        self.a = a
+        self.b = b
+    }
+}
+
+class NSPredicateOperatorTests: XCTestCase {
+
+    // MARK: &&
+
+    func testThatItCreatesACorrectANDPredicate() {
+        executeWithAllBooleanCombinations { lhs, rhs in
+            let matching = PredicateTestHelper(a: lhs, b: rhs)
+            let notMatching = PredicateTestHelper(a: lhs, b: !rhs)
+            let aPredicate = NSPredicate(format: "a == %@", NSNumber(value: lhs))
+            let bPredicate = NSPredicate(format: "b == %@", NSNumber(value: rhs))
+            let compound = aPredicate && bPredicate
+            XCTAssertTrue(compound.evaluate(with: matching))
+            XCTAssertFalse(compound.evaluate(with: notMatching))
+        }
+    }
+
+    // MARK: ||
+
+    func testThatItCreatesACorrectORPredicate() {
+        executeWithAllBooleanCombinations { lhs, rhs in
+            let matchingLHS = PredicateTestHelper(a: lhs, b: !rhs)
+            let matchingRHS = PredicateTestHelper(a: !lhs, b: rhs)
+            let matchingBoth = PredicateTestHelper(a: lhs, b: rhs)
+            let notMatching = PredicateTestHelper(a: !lhs, b: !rhs)
+            let aPredicate = NSPredicate(format: "a == %@", NSNumber(value: lhs))
+            let bPredicate = NSPredicate(format: "b == %@", NSNumber(value: rhs))
+            let compound = aPredicate || bPredicate
+            XCTAssertTrue(compound.evaluate(with: matchingLHS))
+            XCTAssertTrue(compound.evaluate(with: matchingRHS))
+            XCTAssertTrue(compound.evaluate(with: matchingBoth))
+            XCTAssertFalse(compound.evaluate(with: notMatching))
+        }
+    }
+
+    // MARK: Helper
+
+    func executeWithAllBooleanCombinations(block: (Bool, Bool) -> Void) {
+        [true, false].forEach { lhs in
+            [true, false].forEach { rhs in
+                block(lhs, rhs)
+            }
+        }
+    }
+
+}

--- a/ZMUtilities.xcodeproj/project.pbxproj
+++ b/ZMUtilities.xcodeproj/project.pbxproj
@@ -89,6 +89,8 @@
 		BF4A15CC1D47B8860051E8BA /* enterprise-production.xml in Resources */ = {isa = PBXBuildFile; fileRef = BF4A15CB1D47B8860051E8BA /* enterprise-production.xml */; };
 		BF4A15CE1D47BECC0051E8BA /* appstore-sandbox.xml in Resources */ = {isa = PBXBuildFile; fileRef = BF4A15CD1D47BECC0051E8BA /* appstore-sandbox.xml */; };
 		BF4A15D01D47BF360051E8BA /* enterprise-sandbox.xml in Resources */ = {isa = PBXBuildFile; fileRef = BF4A15CF1D47BF360051E8BA /* enterprise-sandbox.xml */; };
+		BF7851BB1E51C8E700E24EB8 /* NSPredicateOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7851BA1E51C8E700E24EB8 /* NSPredicateOperators.swift */; };
+		BF7851BE1E51CA7A00E24EB8 /* NSPredicateOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7851BC1E51C93500E24EB8 /* NSPredicateOperatorTests.swift */; };
 		BFBAE9DB1E01A8F2003FCE49 /* String+Emoji.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFBAE9DA1E01A8F2003FCE49 /* String+Emoji.swift */; };
 		BFBAE9DD1E01A930003FCE49 /* String+EmojiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFBAE9DC1E01A930003FCE49 /* String+EmojiTests.swift */; };
 		F9479C751E4A2D0F0039F55F /* NSOrderedSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9479C741E4A2D0F0039F55F /* NSOrderedSet.swift */; };
@@ -273,6 +275,8 @@
 		BF4A15CB1D47B8860051E8BA /* enterprise-production.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "enterprise-production.xml"; sourceTree = "<group>"; };
 		BF4A15CD1D47BECC0051E8BA /* appstore-sandbox.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; name = "appstore-sandbox.xml"; path = "../appstore-sandbox.xml"; sourceTree = "<group>"; };
 		BF4A15CF1D47BF360051E8BA /* enterprise-sandbox.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "enterprise-sandbox.xml"; sourceTree = "<group>"; };
+		BF7851BA1E51C8E700E24EB8 /* NSPredicateOperators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSPredicateOperators.swift; sourceTree = "<group>"; };
+		BF7851BC1E51C93500E24EB8 /* NSPredicateOperatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSPredicateOperatorTests.swift; sourceTree = "<group>"; };
 		BFBAE9DA1E01A8F2003FCE49 /* String+Emoji.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Emoji.swift"; sourceTree = "<group>"; };
 		BFBAE9DC1E01A930003FCE49 /* String+EmojiTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+EmojiTests.swift"; sourceTree = "<group>"; };
 		F9479C741E4A2D0F0039F55F /* NSOrderedSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSOrderedSet.swift; sourceTree = "<group>"; };
@@ -549,6 +553,7 @@
 				54C388A71C4D5A3A00A55C79 /* NSUUID+Type1.swift */,
 				16EB9B351CE0D5A000883FCF /* NSString+MIMEType.swift */,
 				BFBAE9DA1E01A8F2003FCE49 /* String+Emoji.swift */,
+				BF7851BA1E51C8E700E24EB8 /* NSPredicateOperators.swift */,
 				870FFA811D82B73B007E9806 /* Data+ZMSCrypto.swift */,
 			);
 			path = Public;
@@ -605,6 +610,7 @@
 				BF3A7A611D8AAB8A0034FF40 /* OptionalComparisonTests.swift */,
 				54FA8E811BC6CC3400E42980 /* NSData+ZMSCryptoTests.swift */,
 				54C388A91C4D5AF600A55C79 /* NSUUID+Type1Tests.swift */,
+				BF7851BC1E51C93500E24EB8 /* NSPredicateOperatorTests.swift */,
 				16EB9B371CE0D7D800883FCF /* NSString+MIMETypeTests.swift */,
 				F9FCE0A41C7DBD180092BA68 /* ZMSwiftExceptionHandlerTests.m */,
 				54024FE71DF81CC6009BF6A0 /* DictionaryTests.swift */,
@@ -829,6 +835,7 @@
 				3E88BE231B1F478200232589 /* NSURL+QueryComponents.m in Sources */,
 				3E88BE431B1F478200232589 /* ZMFunctional+noARC.m in Sources */,
 				F9FCE0A31C7DBBD00092BA68 /* ZMSwiftExceptionHandler.m in Sources */,
+				BF7851BB1E51C8E700E24EB8 /* NSPredicateOperators.swift in Sources */,
 				3E88BF631B1F68DC00232589 /* NSOperationQueue+Helpers.m in Sources */,
 				54CA313F1B74F36B00B820C0 /* UnownedObject.swift in Sources */,
 				3E88BE551B1F478200232589 /* ZMTimer.m in Sources */,
@@ -881,6 +888,7 @@
 				54A3430E1E4B7DFB00B48A0F /* NSOrderedSetTests.swift in Sources */,
 				54FA8E821BC6CC3400E42980 /* NSData+ZMSCryptoTests.swift in Sources */,
 				546E8A501B750146009EBA02 /* NSOperationQueue+HelpersTests.m in Sources */,
+				BF7851BE1E51CA7A00E24EB8 /* NSPredicateOperatorTests.swift in Sources */,
 				F9C9A7991CAEA8400039E10C /* ZMEncodedNSUUIDWithTimestampTests.m in Sources */,
 				54C388AA1C4D5AF600A55C79 /* NSUUID+Type1Tests.swift in Sources */,
 				546E8A531B7501D0009EBA02 /* NSUUID+DataTests.m in Sources */,


### PR DESCRIPTION
# What's in this PR?

* Custom operators 😱.
* Add convenience operators to create a compound `NSPredicate` out of two subpredicates using `&&` or `||`.