### PR TITLE
Revert transliterating to latin in search normalization

### DIFF
--- a/Source/NSString+Normalization.m
+++ b/Source/NSString+Normalization.m
@@ -41,7 +41,8 @@
 
 - (instancetype)normalizedForSearch
 {
-    return [[self.normalizedInternal componentsSeparatedByCharactersInSet:NSCharacterSet.punctuationCharacterSet] componentsJoinedByString:@""];
+    NSString *string = [self stringByFoldingWithOptions:NSCaseInsensitiveSearch | NSDiacriticInsensitiveSearch locale:nil];
+    return string.removePunctuationCharacters;
 }
 
 - (instancetype)normalizedString;
@@ -68,6 +69,11 @@
         }
     }
     return result;
+}
+
+- (instancetype)removePunctuationCharacters
+{
+    return [[self componentsSeparatedByCharactersInSet:NSCharacterSet.punctuationCharacterSet] componentsJoinedByString:@""];
 }
 
 - (BOOL)zmHasOnlyWhitespaceCharacters

--- a/Tests/Source/NSString_NormalizationTests.m
+++ b/Tests/Source/NSString_NormalizationTests.m
@@ -104,19 +104,19 @@
     XCTAssertEqualObjects(normalizedString, @"something");
 
     NSString *normalizedString2 = [@"Håkon Bø" normalizedForSearch];
-    XCTAssertEqualObjects(normalizedString2, @"hakon bo");
+    XCTAssertEqualObjects(normalizedString2, @"hakon bø"); // U+00F8 is it's own Unicode character
 }
 
 - (void)testThatItConvertsToLatin_ForSearch
 {
     NSString *normalizedString = [@"שלום" normalizedForSearch];
-    XCTAssertEqualObjects(normalizedString, @"slwm");
+    XCTAssertEqualObjects(normalizedString, @"שלום");
 
     NSString *normalizedString2 = [@"안녕하세요" normalizedForSearch];
-    XCTAssertEqualObjects(normalizedString2, @"annyeonghaseyo");
+    XCTAssertEqualObjects(normalizedString2, @"안녕하세요");
 
     NSString *normalizedString3 = [@"ひらがな" normalizedForSearch];
-    XCTAssertEqualObjects(normalizedString3, @"hiragana");
+    XCTAssertEqualObjects(normalizedString3, @"ひらがな");
 }
 
 - (void)testThatItDoesNotRemoveEmoji_ForSearch


### PR DESCRIPTION
# What's in this PR?

* There were issues when searching in non-latin languages , e.g. in Chinese multiple signs can have the same transliteration, which means all of them will be matched in a search when searching for any of them. In order to avoid these issues no transliteration to latin should happen during the normalization (so only lowercasing and striping diacritics).