### PR TITLE
Fix: crash when installing on iOS 11 simulator.

### DIFF
--- a/Source/FileManager+Protection.swift
+++ b/Source/FileManager+Protection.swift
@@ -31,7 +31,16 @@ extension FileManager {
                 let attributes = [FileAttributeKey.posixPermissions.rawValue: permission] as [String: Any]
                 try createDirectory(at: url, withIntermediateDirectories: true, attributes: attributes)
             }
-            catch let error {
+            catch let error as NSError {
+                // Only when building on simulator
+                #if arch(i386) || arch(x86_64)
+                if error.code == CocoaError.fileWriteUnknown.rawValue {
+                    // This error happens when installing app build with iOS10 on iOS11 simulator
+                    // Seems to be working fine on device or older iOS.
+                    return
+                }
+                #endif
+
                 fatal("Failed to create directory: \(url), error: \(error)")
             }
         }


### PR DESCRIPTION
During automation we noticed that app crashes when installing on iOS11 simulator. It crashes because FileManager fails to create a directory:
```
fatal error: Failed to create directory: file:///<EDITED>/data/Containers/Shared/AppGroup/<APP_ID>/AccountData/<ACCOUNT_ID>/sharedObjectStore/, 
error: Error Domain=NSCocoaErrorDomain Code=512 "The file “AccountData” couldn’t be saved in the folder “<APP_ID>”." 
UserInfo={NSFilePath=<EDITED>/data/Containers/Shared/AppGroup/<APP_ID>/AccountData, 
NSUnderlyingError=0x6040002467e0 {Error Domain=NSPOSIXErrorDomain Code=20 "Not a directory"}}: 
file /Users/jenkins/Desktop/jenkins-agent/workspace/Utility jobs/Create a new version of framework/Source/ZMSAsserts.swift, line 26
```

The underlying reason is unclear as the directory structure before the crash seems to be OK. We try to ignore the error, seems to be working fine.