### PR TITLE
ZIOS-9243: Pseudorandom Generator improvement

### DIFF
--- a/Source/FileManager+FileProtectionLock.swift
+++ b/Source/FileManager+FileProtectionLock.swift
@@ -57,7 +57,7 @@ extension FileManager {
     /// Executes the given block when the file system is unlocked and returns a token.
     /// This token needs to be retain in order for the block to be called.
     ///
-    public func executeWhenFileSystemIsAccessible(_ block: @escaping (Void) -> Void) -> Any? {
+    public func executeWhenFileSystemIsAccessible(_ block: @escaping () -> Void) -> Any? {
         
         #if os(iOS)
         // We need to handle the case when the database file is encrypted by iOS and user never entered the passcode

--- a/Source/NSData+ZMSCrypto.m
+++ b/Source/NSData+ZMSCrypto.m
@@ -95,7 +95,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"SymmetricEncryption";
 {
     NSMutableData *randomData = [NSMutableData dataWithLength:length];
     int success = SecRandomCopyBytes(kSecRandomDefault, length, randomData.mutableBytes);
-    Require(success == 0);
+    Require(success == errSecSuccess);
     return randomData;
 }
 
@@ -120,7 +120,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"SymmetricEncryption";
     {
         uint8_t random[kCCBlockSizeAES128];
         int success = SecRandomCopyBytes(kSecRandomDefault, sizeof(random), random);
-        Require(success == 0);
+        Require(success == errSecSuccess);
         size_t bytesWritten = 0;
         void * const dataOut = ((uint8_t *) [result mutableBytes]) + byteCountWritten;
         size_t const dataOutAvailable = resultLength - byteCountWritten;

--- a/Source/NSUserDefaults+SharedUserDefaults.m
+++ b/Source/NSUserDefaults+SharedUserDefaults.m
@@ -62,7 +62,7 @@
             //create new key
         NSMutableData *newKey = [NSMutableData dataWithLength:kCCKeySizeAES256];
         int success = SecRandomCopyBytes(kSecRandomDefault, newKey.length, (uint8_t *) newKey.mutableBytes);
-        Require(success == 0);
+        Require(success == errSecSuccess);
         key = newKey;
         
 #if TARGET_OS_IPHONE

--- a/Tests/Source/ZMEncodedNSUUIDWithTimestampTests.m
+++ b/Tests/Source/ZMEncodedNSUUIDWithTimestampTests.m
@@ -48,7 +48,7 @@ static unsigned long HOUR_IN_SEC = 60 * 60;
 {
     uint8_t random[kCCKeySizeAES256];
     int success = SecRandomCopyBytes(kSecRandomDefault, kCCKeySizeAES256, random);
-    XCTAssert(success == 0);
+    XCTAssert(success == errSecSuccess);
     return [NSData dataWithBytes:random length:kCCKeySizeAES256];
 }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

As reported by Raphael, `success == 0` should be changed to `success == errSecSuccess`.

### Solutions

I replaced `success == 0` with `success == errSecSuccess` on these files:
- `NSData+ZMSCrypto.m`
- `NSUserDefaults+SharedUserDefaults.m`
- `ZMEncodedNSUUIDWithTimestampTests.m`