### PR TITLE
Don't replace zero width joiner with spaces in string validation

### DIFF
--- a/Source/Validation/ZMStringLengthValidator.m
+++ b/Source/Validation/ZMStringLengthValidator.m
@@ -33,10 +33,14 @@ ZM_EMPTY_ASSERTING_INIT()
     }
     
     NSString *trimmedName = [*ioString stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
-    if ([trimmedName rangeOfCharacterFromSet:[NSCharacterSet controlCharacterSet] options:NSLiteralSearch].location != NSNotFound) {
+    
+    NSMutableCharacterSet *controlSet = NSCharacterSet.controlCharacterSet.mutableCopy;
+    [controlSet removeCharactersInString:@"\u200D"];
+    
+    if ([trimmedName rangeOfCharacterFromSet:controlSet options:NSLiteralSearch].location != NSNotFound) {
         NSMutableString *replaced = [trimmedName mutableCopy];
         do {
-            NSRange r = [replaced rangeOfCharacterFromSet:[NSCharacterSet controlCharacterSet] options:NSLiteralSearch];
+            NSRange r = [replaced rangeOfCharacterFromSet:controlSet options:NSLiteralSearch];
             if (r.location == NSNotFound) {
                 break;
             }

--- a/Source/Validation/ZMStringLengthValidator.m
+++ b/Source/Validation/ZMStringLengthValidator.m
@@ -34,7 +34,7 @@ ZM_EMPTY_ASSERTING_INIT()
     
     NSString *trimmedName = [*ioString stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
     
-    // Eclude zero-width joiner (U+200D) used to create combined Emoji.
+    // Exclude zero-width joiner (U+200D) used to create combined Emoji.
     NSMutableCharacterSet *controlSet = NSCharacterSet.controlCharacterSet.mutableCopy;
     [controlSet removeCharactersInString:@"\u200D"];
     

--- a/Source/Validation/ZMStringLengthValidator.m
+++ b/Source/Validation/ZMStringLengthValidator.m
@@ -34,6 +34,7 @@ ZM_EMPTY_ASSERTING_INIT()
     
     NSString *trimmedName = [*ioString stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
     
+    // Eclude zero-width joiner (U+200D) used to create combined Emoji.
     NSMutableCharacterSet *controlSet = NSCharacterSet.controlCharacterSet.mutableCopy;
     [controlSet removeCharactersInString:@"\u200D"];
     

--- a/Tests/Source/Validation/ZMStringLengthValidatorTests.m
+++ b/Tests/Source/Validation/ZMStringLengthValidatorTests.m
@@ -64,6 +64,39 @@
     XCTAssertNil(error);
 }
 
+- (void)testThatCombinedEmojiPassesValidation_3
+{
+    const NSString *originalValue = @"👨‍👧‍👦";
+    NSString *value = originalValue.copy;
+    NSError *error;
+    BOOL result = [ZMStringLengthValidator validateValue:&value mimimumStringLength:1 maximumSringLength:64 error:&error];
+    XCTAssertTrue(result);
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(originalValue, value);
+}
+
+- (void)testThatCombinedEmojiPassesValidation_4
+{
+    const NSString *originalValue = @"👩‍👩‍👦‍👦";
+    NSString *value = originalValue.copy;
+    NSError *error;
+    BOOL result = [ZMStringLengthValidator validateValue:&value mimimumStringLength:1 maximumSringLength:64 error:&error];
+    XCTAssertTrue(result);
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(originalValue, value);
+}
+
+- (void)testThatItRemovesControlCharactersBetweenCombinedEmoji
+{
+    const NSString *originalValue = @"👩‍👩‍👦‍👦/n👨‍👧‍👦";
+    NSString *value = originalValue.copy;
+    NSError *error;
+    BOOL result = [ZMStringLengthValidator validateValue:&value mimimumStringLength:1 maximumSringLength:64 error:&error];
+    XCTAssertTrue(result);
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(originalValue, value);
+}
+
 - (void)testThatNilIsValid
 {
     NSString *value = nil;

--- a/Tests/String+ExtremeCombiningCharactersTests.swift
+++ b/Tests/String+ExtremeCombiningCharactersTests.swift
@@ -36,6 +36,14 @@ class String_ExtremeCombiningCharactersTests: XCTestCase {
         XCTAssertEqual(string.removingExtremeCombiningCharacters, string)
     }
     
+    func testThatItDoesNotSplitCombinedEmoji() {
+        // GIVEN
+        let string = "👩‍👩‍👦‍👦"
+        
+        // WHEN & THEN
+        XCTAssertEqual(string.removingExtremeCombiningCharacters, string)
+    }
+    
     func testThatItPassesSmallExcessiveDiacritics() {
         // GIVEN
         let string = "t͞e̴s͟t"


### PR DESCRIPTION
## What's new in this PR?

* Don't replace zero width joiner (U+200D) with spaces in string length validation
