### PR TITLE
Added support for secure random number generation on ObjC

### DIFF
--- a/Source/FixedWidthInteger+Random.swift
+++ b/Source/FixedWidthInteger+Random.swift
@@ -35,7 +35,7 @@ public extension FixedWidthInteger {
     ///
     public static func secureRandomNumber(upperBound: Self) -> Self {
         
-        guard upperBound != 0 else { return 0 }
+        guard upperBound != 0, upperBound != Self.min else { return 0 }
         
         var random: Self
         

--- a/Source/FixedWidthInteger+Random.swift
+++ b/Source/FixedWidthInteger+Random.swift
@@ -35,7 +35,7 @@ public extension FixedWidthInteger {
     ///
     public static func secureRandomNumber(upperBound: Self) -> Self {
         
-        guard upperBound != 0, upperBound != Self.min else { return 0 }
+        assert(upperBound != 0 && upperBound != Self.min, "Upper bound should not be zero or equal to the minimum possible value")
         
         var random: Self
         

--- a/Source/FixedWidthInteger+Random.swift
+++ b/Source/FixedWidthInteger+Random.swift
@@ -19,34 +19,42 @@
 
 import Foundation
 
-public extension UInt {
+public extension FixedWidthInteger {
+    
+    private var abs: Self {
+        if self < 0 {
+            return 0 - self
+        } else {
+            return self
+        }
+    }
     
     /// Returns a random number within the range [0, upperBound) using the
     /// Data.secureRandomData(length:) method. This implementation is
     /// modulo bias free.
     ///
-    public static func secureRandomNumber(upperBound: UInt) -> UInt {
+    public static func secureRandomNumber(upperBound: Self) -> Self {
         
         guard upperBound != 0 else { return 0 }
         
-        var random: UInt
+        var random: Self
         
         // To eliminate modulo bias, we must ensure range of possible random
         // numbers is evenly divisible by the upper bound. We do this by
         // trimming the excess remainder off the lower bound (0)
         //
-        let min = (UInt.min &- upperBound) % upperBound
+        let min = (Self.min &- upperBound) % upperBound
         
         repeat {
             // get enough random bytes to fill UInt
-            let data = Data.secureRandomData(length: UInt(MemoryLayout<UInt>.size))
+            let data = Data.secureRandomData(length: UInt(MemoryLayout<Self>.size))
             
             // extract the UInt
-            random = data.withUnsafeBytes { (pointer: UnsafePointer<UInt>) -> UInt in
+            random = data.withUnsafeBytes { (pointer: UnsafePointer<Self>) -> Self in
                 return pointer.pointee
             }
             
-        } while random < min
+        } while random.abs < min
         
         return random % upperBound
     }
@@ -55,7 +63,7 @@ public extension UInt {
 /// Extension for NSNumber so we can support ObjC
 public extension NSNumber {
     public static func secureRandomNumber(upperBound: UInt32) -> UInt32 {
-        return UInt32(UInt.secureRandomNumber(upperBound: UInt(upperBound)))
+        return UInt32.secureRandomNumber(upperBound: upperBound)
     }
 }
 

--- a/Source/UInt+Random.swift
+++ b/Source/UInt+Random.swift
@@ -51,3 +51,11 @@ public extension UInt {
         return random % upperBound
     }
 }
+
+/// Extension for NSNumber so we can support ObjC
+public extension NSNumber {
+    public static func secureRandomNumber(upperBound: UInt32) -> UInt32 {
+        return UInt32(UInt.secureRandomNumber(upperBound: UInt(upperBound)))
+    }
+}
+

--- a/Tests/FixedWidthInteger_RandomTests.swift
+++ b/Tests/FixedWidthInteger_RandomTests.swift
@@ -49,4 +49,56 @@ class FixedWidthInteger_RandomTests: XCTestCase {
         XCTAssertNotNil(UInt.secureRandomNumber(upperBound: UInt.max))
     }
     
+    /// Tests for all numeric types inheriting from FixedWidthInteger
+    /// https://developer.apple.com/documentation/swift/fixedwidthinteger#relationships
+    
+    func testThatItGeneratesANumberByProvidingBounds_Int() {
+        XCTAssertEqual(Int.secureRandomNumber(upperBound: Int.min), 0)
+        XCTAssertNotNil(Int.secureRandomNumber(upperBound: Int.max))
+    }
+    
+    func testThatItGeneratesANumberByProvidingBounds_Int8() {
+        XCTAssertEqual(Int8.secureRandomNumber(upperBound: Int8.min), 0)
+        XCTAssertNotNil(Int8.secureRandomNumber(upperBound: Int8.max))
+    }
+    
+    func testThatItGeneratesANumberByProvidingBounds_Int16() {
+        XCTAssertEqual(Int16.secureRandomNumber(upperBound: Int16.min), 0)
+        XCTAssertNotNil(Int16.secureRandomNumber(upperBound: Int16.max))
+    }
+    
+    func testThatItGeneratesANumberByProvidingBounds_Int32() {
+        XCTAssertEqual(Int32.secureRandomNumber(upperBound: Int32.min), 0)
+        XCTAssertNotNil(Int32.secureRandomNumber(upperBound: Int32.max))
+    }
+    
+    func testThatItGeneratesANumberByProvidingBounds_Int64() {
+        XCTAssertEqual(Int64.secureRandomNumber(upperBound: Int64.min), 0)
+        XCTAssertNotNil(Int64.secureRandomNumber(upperBound: Int64.max))
+    }
+    
+    func testThatItGeneratesANumberByProvidingBounds_UInt() {
+        XCTAssertEqual(UInt.secureRandomNumber(upperBound: UInt.min), 0)
+        XCTAssertNotNil(UInt.secureRandomNumber(upperBound: UInt.max))
+    }
+    
+    func testThatItGeneratesANumberByProvidingBounds_UInt8() {
+        XCTAssertEqual(UInt8.secureRandomNumber(upperBound: UInt8.min), 0)
+        XCTAssertNotNil(UInt8.secureRandomNumber(upperBound: UInt8.max))
+    }
+    
+    func testThatItGeneratesANumberByProvidingBounds_UInt16() {
+        XCTAssertEqual(UInt16.secureRandomNumber(upperBound: UInt16.min), 0)
+        XCTAssertNotNil(UInt16.secureRandomNumber(upperBound: UInt16.max))
+    }
+    
+    func testThatItGeneratesANumberByProvidingBounds_UInt32() {
+        XCTAssertEqual(UInt32.secureRandomNumber(upperBound: UInt32.min), 0)
+        XCTAssertNotNil(UInt32.secureRandomNumber(upperBound: UInt32.max))
+    }
+    
+    func testThatItGeneratesANumberByProvidingBounds_UInt64() {
+        XCTAssertEqual(UInt64.secureRandomNumber(upperBound: UInt64.min), 0)
+        XCTAssertNotNil(UInt64.secureRandomNumber(upperBound: UInt64.max))
+    }
 }

--- a/Tests/FixedWidthInteger_RandomTests.swift
+++ b/Tests/FixedWidthInteger_RandomTests.swift
@@ -18,15 +18,25 @@
 
 import XCTest
 
-class UInt_RandomTests: XCTestCase {
+class FixedWidthInteger_RandomTests: XCTestCase {
     
-    func testThatTheGeneratedNumberIsInRange() {
+    func testThatTheGeneratedNumberIsInRangeWithUInt() {
         
         let upperBound: UInt = 2
         let range = 0..<upperBound
         
         for _ in 0..<100 {
             XCTAssertTrue(range.contains(UInt.secureRandomNumber(upperBound: upperBound)))
+        }
+    }
+    
+    func testThatTheGeneratedNumberIsInRangeWithInt() {
+        
+        let upperBound: Int = 100
+        let range = -upperBound..<upperBound
+        
+        for _ in 0..<100 {
+            XCTAssertTrue(range.contains(Int.secureRandomNumber(upperBound: upperBound)))
         }
     }
     
@@ -38,4 +48,5 @@ class UInt_RandomTests: XCTestCase {
     func testThatItGeneratesANumberWhenThenUpperBoundIsMax() {
         XCTAssertNotNil(UInt.secureRandomNumber(upperBound: UInt.max))
     }
+    
 }

--- a/Tests/FixedWidthInteger_RandomTests.swift
+++ b/Tests/FixedWidthInteger_RandomTests.swift
@@ -41,7 +41,6 @@ class FixedWidthInteger_RandomTests: XCTestCase {
     }
     
     func testThatItGeneratesZeroWhenTheUpperBoundIsZeroOrOne() {
-        XCTAssertEqual(UInt.secureRandomNumber(upperBound: 0), 0)
         XCTAssertEqual(UInt.secureRandomNumber(upperBound: 1), 0)
     }
     
@@ -53,52 +52,42 @@ class FixedWidthInteger_RandomTests: XCTestCase {
     /// https://developer.apple.com/documentation/swift/fixedwidthinteger#relationships
     
     func testThatItGeneratesANumberByProvidingBounds_Int() {
-        XCTAssertEqual(Int.secureRandomNumber(upperBound: Int.min), 0)
         XCTAssertNotNil(Int.secureRandomNumber(upperBound: Int.max))
     }
     
     func testThatItGeneratesANumberByProvidingBounds_Int8() {
-        XCTAssertEqual(Int8.secureRandomNumber(upperBound: Int8.min), 0)
         XCTAssertNotNil(Int8.secureRandomNumber(upperBound: Int8.max))
     }
     
     func testThatItGeneratesANumberByProvidingBounds_Int16() {
-        XCTAssertEqual(Int16.secureRandomNumber(upperBound: Int16.min), 0)
         XCTAssertNotNil(Int16.secureRandomNumber(upperBound: Int16.max))
     }
     
     func testThatItGeneratesANumberByProvidingBounds_Int32() {
-        XCTAssertEqual(Int32.secureRandomNumber(upperBound: Int32.min), 0)
         XCTAssertNotNil(Int32.secureRandomNumber(upperBound: Int32.max))
     }
     
     func testThatItGeneratesANumberByProvidingBounds_Int64() {
-        XCTAssertEqual(Int64.secureRandomNumber(upperBound: Int64.min), 0)
         XCTAssertNotNil(Int64.secureRandomNumber(upperBound: Int64.max))
     }
     
     func testThatItGeneratesANumberByProvidingBounds_UInt() {
-        XCTAssertEqual(UInt.secureRandomNumber(upperBound: UInt.min), 0)
         XCTAssertNotNil(UInt.secureRandomNumber(upperBound: UInt.max))
     }
     
     func testThatItGeneratesANumberByProvidingBounds_UInt8() {
-        XCTAssertEqual(UInt8.secureRandomNumber(upperBound: UInt8.min), 0)
         XCTAssertNotNil(UInt8.secureRandomNumber(upperBound: UInt8.max))
     }
     
     func testThatItGeneratesANumberByProvidingBounds_UInt16() {
-        XCTAssertEqual(UInt16.secureRandomNumber(upperBound: UInt16.min), 0)
         XCTAssertNotNil(UInt16.secureRandomNumber(upperBound: UInt16.max))
     }
     
     func testThatItGeneratesANumberByProvidingBounds_UInt32() {
-        XCTAssertEqual(UInt32.secureRandomNumber(upperBound: UInt32.min), 0)
         XCTAssertNotNil(UInt32.secureRandomNumber(upperBound: UInt32.max))
     }
     
     func testThatItGeneratesANumberByProvidingBounds_UInt64() {
-        XCTAssertEqual(UInt64.secureRandomNumber(upperBound: UInt64.min), 0)
         XCTAssertNotNil(UInt64.secureRandomNumber(upperBound: UInt64.max))
     }
 }

--- a/WireUtilities.xcodeproj/project.pbxproj
+++ b/WireUtilities.xcodeproj/project.pbxproj
@@ -111,8 +111,8 @@
 		BF9D0B091F1CF3F8005D4C31 /* Optional+Apply.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9D0B071F1CF3F5005D4C31 /* Optional+Apply.swift */; };
 		BFBAE9DB1E01A8F2003FCE49 /* String+Emoji.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFBAE9DA1E01A8F2003FCE49 /* String+Emoji.swift */; };
 		BFBAE9DD1E01A930003FCE49 /* String+EmojiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFBAE9DC1E01A930003FCE49 /* String+EmojiTests.swift */; };
-		EECE48C71FFBE45D0015BAE8 /* UInt_RandomTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECE48C61FFBE45D0015BAE8 /* UInt_RandomTests.swift */; };
-		EECE92301FFBC5540096387F /* UInt+Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECE922F1FFBC5540096387F /* UInt+Random.swift */; };
+		EECE48C71FFBE45D0015BAE8 /* FixedWidthInteger_RandomTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECE48C61FFBE45D0015BAE8 /* FixedWidthInteger_RandomTests.swift */; };
+		EECE92301FFBC5540096387F /* FixedWidthInteger+Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECE922F1FFBC5540096387F /* FixedWidthInteger+Random.swift */; };
 		EF18C7D21F9E37CA0085A832 /* String+Filename.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF18C7D11F9E37CA0085A832 /* String+Filename.swift */; };
 		EF18C7DA1F9E3D3B0085A832 /* String+FilenameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF18C7D91F9E3D3B0085A832 /* String+FilenameTests.swift */; };
 		F9479C751E4A2D0F0039F55F /* NSOrderedSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9479C741E4A2D0F0039F55F /* NSOrderedSet.swift */; };
@@ -308,8 +308,8 @@
 		BF9D0B071F1CF3F5005D4C31 /* Optional+Apply.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Optional+Apply.swift"; sourceTree = "<group>"; };
 		BFBAE9DA1E01A8F2003FCE49 /* String+Emoji.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Emoji.swift"; sourceTree = "<group>"; };
 		BFBAE9DC1E01A930003FCE49 /* String+EmojiTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+EmojiTests.swift"; sourceTree = "<group>"; };
-		EECE48C61FFBE45D0015BAE8 /* UInt_RandomTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UInt_RandomTests.swift; sourceTree = "<group>"; };
-		EECE922F1FFBC5540096387F /* UInt+Random.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UInt+Random.swift"; sourceTree = "<group>"; };
+		EECE48C61FFBE45D0015BAE8 /* FixedWidthInteger_RandomTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedWidthInteger_RandomTests.swift; sourceTree = "<group>"; };
+		EECE922F1FFBC5540096387F /* FixedWidthInteger+Random.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FixedWidthInteger+Random.swift"; sourceTree = "<group>"; };
 		EF18C7D11F9E37CA0085A832 /* String+Filename.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Filename.swift"; sourceTree = "<group>"; };
 		EF18C7D91F9E3D3B0085A832 /* String+FilenameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+FilenameTests.swift"; sourceTree = "<group>"; };
 		F9479C741E4A2D0F0039F55F /* NSOrderedSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSOrderedSet.swift; sourceTree = "<group>"; };
@@ -479,7 +479,7 @@
 				54181A4F1F594E4100155ABC /* FileManager+Move.swift */,
 				54181A531F594F6B00155ABC /* FileManager+Protection.swift */,
 				54181A551F594FD800155ABC /* FileManager+FileProtectionLock.swift */,
-				EECE922F1FFBC5540096387F /* UInt+Random.swift */,
+				EECE922F1FFBC5540096387F /* FixedWidthInteger+Random.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -633,7 +633,7 @@
 			isa = PBXGroup;
 			children = (
 				F9C9A7BE1CAEAFE10039E10C /* Validation */,
-				EECE48C61FFBE45D0015BAE8 /* UInt_RandomTests.swift */,
+				EECE48C61FFBE45D0015BAE8 /* FixedWidthInteger_RandomTests.swift */,
 				F9C9A7971CAEA83B0039E10C /* ZMEncodedNSUUIDWithTimestampTests.m */,
 				F9C9A78C1CAEA00D0039E10C /* NSString_NormalizationTests.m */,
 				546E8A4B1B74FF8F009EBA02 /* NSData+ZMAdditionsTests.m */,
@@ -879,7 +879,7 @@
 				54C388A81C4D5A3B00A55C79 /* NSUUID+Type1.swift in Sources */,
 				54024FE61DF81C8E009BF6A0 /* Dictionary.swift in Sources */,
 				54CA313D1B74F36B00B820C0 /* SwiftDebugging.swift in Sources */,
-				EECE92301FFBC5540096387F /* UInt+Random.swift in Sources */,
+				EECE92301FFBC5540096387F /* FixedWidthInteger+Random.swift in Sources */,
 				F9C9A7AC1CAEACB10039E10C /* ZMEmailAddressValidator.m in Sources */,
 				3E88BE3D1B1F478200232589 /* ZMDebugHelpers.m in Sources */,
 				091799531B7DFA1500E60DD9 /* ZMMobileProvisionParser.m in Sources */,
@@ -940,7 +940,7 @@
 				F9D381B21B70B94B00E6E4EB /* NSSet+ZMUTests.m in Sources */,
 				54181A581F59516600155ABC /* FileManager+ProtectionTests.swift in Sources */,
 				F9C9A7C61CAEAFE10039E10C /* ZMEmailAddressValidatorTests.m in Sources */,
-				EECE48C71FFBE45D0015BAE8 /* UInt_RandomTests.swift in Sources */,
+				EECE48C71FFBE45D0015BAE8 /* FixedWidthInteger_RandomTests.swift in Sources */,
 				091799741B7E2E4D00E60DD9 /* ZMAPNSEnvironmentTests.m in Sources */,
 				546E8A591B750384009EBA02 /* NSManagedObjectContext+WireUtilitiesTests.m in Sources */,
 				546E8A4C1B74FF8F009EBA02 /* NSData+ZMAdditionsTests.m in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Issues

`secureRandomNumberWithUpperBound` was not visible in Objective-C, since `uint32_t` is a primitive type.

### Solutions

I've added a bridge that does the same thing using `NSNumber` as the base class for the static method. Not the most elegant solution, I know - suggestions are welcome!
