### PR TITLE
Add a simple result enum type

### DIFF
--- a/Source/Result.swift
+++ b/Source/Result.swift
@@ -1,0 +1,63 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+public enum Result<T> {
+    case success(T)
+    case failure(Error)
+}
+
+public enum VoidResult {
+    case success
+    case failure(Error)
+}
+
+public extension Result {
+    func map<U>(_ transform: (T) throws -> U) -> Result<U> {
+        switch self {
+        case .success(let value):
+            do {
+                return .success(try transform(value))
+            } catch {
+                return .failure(error)
+            }
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+}
+
+public extension Result {
+    var value: T? {
+        guard case let .success(value) = self else { return nil }
+        return value
+    }
+    
+    var error: Error? {
+        guard case let .failure(error) = self else { return nil }
+        return error
+    }
+}
+
+public extension VoidResult {
+    var error: Error? {
+        guard case let .failure(error) = self else { return nil }
+        return error
+    }
+}

--- a/Tests/ResultTests.swift
+++ b/Tests/ResultTests.swift
@@ -28,13 +28,24 @@ class ResultTests: XCTestCase {
         let transformed = sut.map(String.init)
         
         // Then
-        
         XCTAssertEqual(transformed.value, "42")
+    }
+    
+    func testThatItCanMapAResult_Throwing() {
+        // Given
+        let error = NSError(domain: "", code: 0, userInfo: nil)
+        let sut = Result<Int>.success(42)
+        
+        // When
+        let transformed = sut.map { _ in throw error }
+        
+        // Then
+        XCTAssertEqual(transformed.error as NSError?, error)
     }
     
     func testThatItCanMapAResult_Error() {
         // Given
-        let error = NSError()
+        let error = NSError(domain: "", code: 0, userInfo: nil)
         let sut = Result<Int>.failure(error)
         
         // When

--- a/Tests/ResultTests.swift
+++ b/Tests/ResultTests.swift
@@ -1,0 +1,46 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+import WireUtilities
+
+class ResultTests: XCTestCase {
+    func testThatItCanMapAResult_Success() {
+        // Given
+        let sut = Result<Int>.success(42)
+        
+        // When
+        let transformed = sut.map(String.init)
+        
+        // Then
+        
+        XCTAssertEqual(transformed.value, "42")
+    }
+    
+    func testThatItCanMapAResult_Error() {
+        // Given
+        let error = NSError()
+        let sut = Result<Int>.failure(error)
+        
+        // When
+        let transformed = sut.map(String.init)
+        
+        // Then
+        XCTAssertEqual(transformed.error as NSError?, error)
+    }
+}

--- a/WireUtilities.xcodeproj/project.pbxproj
+++ b/WireUtilities.xcodeproj/project.pbxproj
@@ -112,6 +112,8 @@
 		BF9D0B091F1CF3F8005D4C31 /* Optional+Apply.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9D0B071F1CF3F5005D4C31 /* Optional+Apply.swift */; };
 		BFBAE9DB1E01A8F2003FCE49 /* String+Emoji.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFBAE9DA1E01A8F2003FCE49 /* String+Emoji.swift */; };
 		BFBAE9DD1E01A930003FCE49 /* String+EmojiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFBAE9DC1E01A930003FCE49 /* String+EmojiTests.swift */; };
+		D53DB99F203ED59C00655CB4 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53DB99E203ED59C00655CB4 /* Result.swift */; };
+		D53DB9A2203ED6E100655CB4 /* ResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53DB9A0203ED6DC00655CB4 /* ResultTests.swift */; };
 		EECE48C71FFBE45D0015BAE8 /* FixedWidthInteger_RandomTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECE48C61FFBE45D0015BAE8 /* FixedWidthInteger_RandomTests.swift */; };
 		EECE92301FFBC5540096387F /* FixedWidthInteger+Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECE922F1FFBC5540096387F /* FixedWidthInteger+Random.swift */; };
 		EF18C7D21F9E37CA0085A832 /* String+Filename.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF18C7D11F9E37CA0085A832 /* String+Filename.swift */; };
@@ -308,6 +310,8 @@
 		BF9D0B071F1CF3F5005D4C31 /* Optional+Apply.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Optional+Apply.swift"; sourceTree = "<group>"; };
 		BFBAE9DA1E01A8F2003FCE49 /* String+Emoji.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Emoji.swift"; sourceTree = "<group>"; };
 		BFBAE9DC1E01A930003FCE49 /* String+EmojiTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+EmojiTests.swift"; sourceTree = "<group>"; };
+		D53DB99E203ED59C00655CB4 /* Result.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
+		D53DB9A0203ED6DC00655CB4 /* ResultTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultTests.swift; sourceTree = "<group>"; };
 		EECE48C61FFBE45D0015BAE8 /* FixedWidthInteger_RandomTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedWidthInteger_RandomTests.swift; sourceTree = "<group>"; };
 		EECE922F1FFBC5540096387F /* FixedWidthInteger+Random.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FixedWidthInteger+Random.swift"; sourceTree = "<group>"; };
 		EF18C7D11F9E37CA0085A832 /* String+Filename.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Filename.swift"; sourceTree = "<group>"; };
@@ -453,6 +457,7 @@
 				F9C9A79F1CAEACB10039E10C /* Validation */,
 				54CA31521B74F7D400B820C0 /* NSManagedObjectContext+WireUtilities.m */,
 				163FB9051F2229DF00802AF4 /* DispatchGroupContext.swift */,
+				D53DB99E203ED59C00655CB4 /* Result.swift */,
 				F9C9A7931CAEA7200039E10C /* ZMEncodedNSUUIDWithTimestamp.m */,
 				3E88BF661B1F693F00232589 /* NSData+ZMAdditions.m */,
 				543B04A01BC6B693008C2912 /* NSData+ZMSCrypto.m */,
@@ -631,6 +636,7 @@
 			children = (
 				F9C9A7BE1CAEAFE10039E10C /* Validation */,
 				EECE48C61FFBE45D0015BAE8 /* FixedWidthInteger_RandomTests.swift */,
+				D53DB9A0203ED6DC00655CB4 /* ResultTests.swift */,
 				F9C9A7971CAEA83B0039E10C /* ZMEncodedNSUUIDWithTimestampTests.m */,
 				F9C9A78C1CAEA00D0039E10C /* NSString_NormalizationTests.m */,
 				546E8A4B1B74FF8F009EBA02 /* NSData+ZMAdditionsTests.m */,
@@ -915,6 +921,7 @@
 				16D964DC1F79454000390417 /* SelfUnregisteringNotificationCenterToken.swift in Sources */,
 				16EB9B361CE0D5A000883FCF /* NSString+MIMEType.swift in Sources */,
 				870FFA821D82B73B007E9806 /* Data+ZMSCrypto.swift in Sources */,
+				D53DB99F203ED59C00655CB4 /* Result.swift in Sources */,
 				8735AE6F2035E3BC00DCE66E /* StringLengthValidator.swift in Sources */,
 				F9479C751E4A2D0F0039F55F /* NSOrderedSet.swift in Sources */,
 			);
@@ -930,6 +937,7 @@
 				F9C9A7C81CAEAFE10039E10C /* ZMStringLengthValidatorTests.m in Sources */,
 				54024FE81DF81CC6009BF6A0 /* DictionaryTests.swift in Sources */,
 				BF3493F61EC36A6400B0C314 /* Iterator+ContainmentTests.swift in Sources */,
+				D53DB9A2203ED6E100655CB4 /* ResultTests.swift in Sources */,
 				F9C9A7C71CAEAFE10039E10C /* ZMPhoneNumberValidatorTests.m in Sources */,
 				F9D381AE1B70B93800E6E4EB /* ZMTimerTests.m in Sources */,
 				168B158C1F25F67600AB3C44 /* DispatchGroupQueueTests.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

* Add a simple result enum type including helper accessors and `map` implementation.
* It would be nice to add a `flatMap` function at some point to avoid `Result<Result<T>>` types.