### PR TITLE
Basic one-way function composition

### DIFF
--- a/Source/Composition.swift
+++ b/Source/Composition.swift
@@ -1,0 +1,25 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+/// Function composition operator: (f1 ∘ f2)(x) = f1(f2(x))
+infix operator => : AdditionPrecedence
+public func => <A, B, C>(f: @escaping (B) -> C, g: @escaping (A) -> B) -> (A) -> C {
+    return { x in f(g(x)) }
+}

--- a/Source/Composition.swift
+++ b/Source/Composition.swift
@@ -19,7 +19,7 @@
 import Foundation
 
 /// Function composition operator: (f1 ∘ f2)(x) = f1(f2(x))
-infix operator => : AdditionPrecedence
-public func => <A, B, C>(f: @escaping (B) -> C, g: @escaping (A) -> B) -> (A) -> C {
+infix operator >>> : AdditionPrecedence
+public func >>> <A, B, C>(f: @escaping (B) -> C, g: @escaping (A) -> B) -> (A) -> C {
     return { x in f(g(x)) }
 }

--- a/Source/Result.swift
+++ b/Source/Result.swift
@@ -44,15 +44,6 @@ public extension Result {
 }
 
 public extension Result {
-    var voidResult: VoidResult {
-        switch self {
-        case .success: return .success
-        case .failure(let error): return .failure(error)
-        }
-    }
-}
-
-public extension Result {
     var value: T? {
         guard case let .success(value) = self else { return nil }
         return value
@@ -65,6 +56,13 @@ public extension Result {
 }
 
 public extension VoidResult {
+    init<T>(result: Result<T>) {
+        switch result {
+        case .success: self = .success
+        case .failure(let error): self = .failure(error)
+        }
+    }
+    
     var error: Error? {
         guard case let .failure(error) = self else { return nil }
         return error

--- a/Tests/ResultTests.swift
+++ b/Tests/ResultTests.swift
@@ -60,7 +60,7 @@ class ResultTests: XCTestCase {
         let sut = Result<Int>.success(42)
         
         // When
-        let transformed = sut.voidResult
+        let transformed = VoidResult(result: sut)
         
         // Then
         XCTAssertNil(transformed.error)
@@ -72,7 +72,7 @@ class ResultTests: XCTestCase {
         let sut = Result<Int>.failure(error)
         
         // When
-        let transformed = sut.voidResult
+        let transformed = VoidResult(result: sut)
         
         // Then
         XCTAssertEqual(transformed.error as NSError?, error)

--- a/WireUtilities.xcodeproj/project.pbxproj
+++ b/WireUtilities.xcodeproj/project.pbxproj
@@ -96,6 +96,7 @@
 		877F501D1E719B2B00894C90 /* String+ExtremeCombiningCharacters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F501C1E719B2B00894C90 /* String+ExtremeCombiningCharacters.swift */; };
 		877F501F1E71B69C00894C90 /* String+ExtremeCombiningCharactersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F501E1E71B69C00894C90 /* String+ExtremeCombiningCharactersTests.swift */; };
 		877F50211E729CCF00894C90 /* excessive_diacritics.txt in Resources */ = {isa = PBXBuildFile; fileRef = 877F50201E729CCF00894C90 /* excessive_diacritics.txt */; };
+		87B6489C2076078A002FC9E7 /* Composition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B6489B2076078A002FC9E7 /* Composition.swift */; };
 		87ECBDD51E78457C00596836 /* ExtremeCombiningCharactersValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87ECBDD41E78457C00596836 /* ExtremeCombiningCharactersValidator.swift */; };
 		BF3493F41EC362D400B0C314 /* Iterator+Containment.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF3493F31EC362D400B0C314 /* Iterator+Containment.swift */; };
 		BF3493F61EC36A6400B0C314 /* Iterator+ContainmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF3493F51EC36A6400B0C314 /* Iterator+ContainmentTests.swift */; };
@@ -295,6 +296,7 @@
 		877F501C1E719B2B00894C90 /* String+ExtremeCombiningCharacters.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+ExtremeCombiningCharacters.swift"; sourceTree = "<group>"; };
 		877F501E1E71B69C00894C90 /* String+ExtremeCombiningCharactersTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+ExtremeCombiningCharactersTests.swift"; sourceTree = "<group>"; };
 		877F50201E729CCF00894C90 /* excessive_diacritics.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = excessive_diacritics.txt; sourceTree = "<group>"; };
+		87B6489B2076078A002FC9E7 /* Composition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Composition.swift; sourceTree = "<group>"; };
 		87ECBDD41E78457C00596836 /* ExtremeCombiningCharactersValidator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtremeCombiningCharactersValidator.swift; sourceTree = "<group>"; };
 		BF3493F31EC362D400B0C314 /* Iterator+Containment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Iterator+Containment.swift"; sourceTree = "<group>"; };
 		BF3493F51EC36A6400B0C314 /* Iterator+ContainmentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Iterator+ContainmentTests.swift"; sourceTree = "<group>"; };
@@ -458,6 +460,7 @@
 				54CA31521B74F7D400B820C0 /* NSManagedObjectContext+WireUtilities.m */,
 				163FB9051F2229DF00802AF4 /* DispatchGroupContext.swift */,
 				D53DB99E203ED59C00655CB4 /* Result.swift */,
+				87B6489B2076078A002FC9E7 /* Composition.swift */,
 				F9C9A7931CAEA7200039E10C /* ZMEncodedNSUUIDWithTimestamp.m */,
 				3E88BF661B1F693F00232589 /* NSData+ZMAdditions.m */,
 				543B04A01BC6B693008C2912 /* NSData+ZMSCrypto.m */,
@@ -913,6 +916,7 @@
 				F9C9A78B1CAE9F9A0039E10C /* NSString+Normalization.m in Sources */,
 				163FB9061F2229DF00802AF4 /* DispatchGroupContext.swift in Sources */,
 				3E88BE1B1B1F478200232589 /* NSOrderedSet+Zeta.m in Sources */,
+				87B6489C2076078A002FC9E7 /* Composition.swift in Sources */,
 				091799651B7E04FE00E60DD9 /* ZMDeploymentEnvironment.m in Sources */,
 				F9C9A7AE1CAEACB10039E10C /* ZMPhoneNumberValidator.m in Sources */,
 				3E88BE1F1B1F478200232589 /* NSSet+Zeta.m in Sources */,


### PR DESCRIPTION
Nice functional utility: binary operator that takes 2 functions and composes the new function from them:

`(f1 ∘ f2)(x) = f1(f2(x))`

Usage example: https://github.com/wireapp/wire-ios-sync-engine/pull/731/files