### PR TITLE
Allow throwing functions inside a performAndWait block

### DIFF
--- a/Source/NSmanagedObjectContext+PerformGrouped.swift
+++ b/Source/NSmanagedObjectContext+PerformGrouped.swift
@@ -18,18 +18,18 @@
 
 public extension NSManagedObjectContext {
 
-    @discardableResult func performGroupedBlockAndWait<T>(_ execute: @escaping () -> T) -> T {
+    @discardableResult func performGroupedBlockAndWait<T>(_ execute: @escaping () throws -> T) rethrows -> T {
         var result: T!
-        performGroupedBlockAndWait {
-            result = execute()
+        try performGroupedBlockAndWait {
+            result = try execute()
         }
         return result
     }
     
-    @discardableResult func performGroupedBlockAndWait<T>(_ execute: @escaping () -> T?) -> T? {
+    @discardableResult func performGroupedBlockAndWait<T>(_ execute: @escaping () throws -> T?) rethrows -> T? {
         var result: T?
-        performGroupedBlockAndWait {
-            result = execute()
+        try performGroupedBlockAndWait {
+            result = try execute()
         }
         return result
     }


### PR DESCRIPTION
## What's new in this PR?

* Allow throwing functions inside a `performGroupedBlockedAndWait` block.