### PR TITLE
Add init to create a VoidResult from an optional Error

### DIFF
--- a/Source/Result.swift
+++ b/Source/Result.swift
@@ -63,6 +63,14 @@ public extension VoidResult {
         }
     }
     
+    init(error: Error?) {
+        if let error = error {
+            self = .failure(error)
+        } else {
+            self = .success
+        }
+    }
+    
     var error: Error? {
         guard case let .failure(error) = self else { return nil }
         return error

--- a/Tests/ResultTests.swift
+++ b/Tests/ResultTests.swift
@@ -77,5 +77,21 @@ class ResultTests: XCTestCase {
         // Then
         XCTAssertEqual(transformed.error as NSError?, error)
     }
+    
+    func testThatItCanInitializeAVoidResultFromAnError() {
+        // Given
+        let error = NSError(domain: "", code: 0, userInfo: nil)
+        
+        // When
+        let result = VoidResult(error: error)
+        
+        // Then
+        XCTAssertEqual(result.error as NSError?, error)
+    }
+    
+    func testThatItCanInitializeAVoidResultFromAnError_Nil() {
+        // When & Then
+        XCTAssertNil(VoidResult(error: nil).error)
+    }
 
 }


### PR DESCRIPTION
## What's in this PR?

* Add init to create a VoidResult from an optional Error.