### PR TITLE
Add non-mutable validators for better Swift import

### DIFF
--- a/Source/Public/ZMEmailAddressValidator.h
+++ b/Source/Public/ZMEmailAddressValidator.h
@@ -21,4 +21,6 @@
 
 @interface ZMEmailAddressValidator : NSObject <ZMPropertyValidator>
 
++ (BOOL)isValidEmailAddress:(NSString * _Nullable)emailAddress;
+
 @end

--- a/Source/Public/ZMPhoneNumberValidator.h
+++ b/Source/Public/ZMPhoneNumberValidator.h
@@ -21,4 +21,6 @@
 
 @interface ZMPhoneNumberValidator : NSObject <ZMPropertyValidator>
 
++ (BOOL)isValidPhoneNumber:(NSString * _Nullable)phoneNumber;
+
 @end

--- a/Source/Validation/ZMEmailAddressValidator.m
+++ b/Source/Validation/ZMEmailAddressValidator.m
@@ -181,10 +181,6 @@ ZM_EMPTY_ASSERTING_INIT()
 
 + (BOOL)isValidEmailAddress:(NSString *)emailAddress
 {
-    if (emailAddress == nil) {
-        return NO;
-    }
-
     NSString* value = [emailAddress copy];
     return [self validateValue:&value error:nil];
 }

--- a/Source/Validation/ZMEmailAddressValidator.m
+++ b/Source/Validation/ZMEmailAddressValidator.m
@@ -179,4 +179,14 @@ ZM_EMPTY_ASSERTING_INIT()
     return YES;
 }
 
++ (BOOL)isValidEmailAddress:(NSString *)emailAddress
+{
+    if (emailAddress == nil) {
+        return NO;
+    }
+
+    NSString* value = [emailAddress copy];
+    return [self validateValue:&value error:nil];
+}
+
 @end

--- a/Source/Validation/ZMPhoneNumberValidator.m
+++ b/Source/Validation/ZMPhoneNumberValidator.m
@@ -87,10 +87,6 @@ ZM_EMPTY_ASSERTING_INIT()
 
 + (BOOL)isValidPhoneNumber:(NSString *)phoneNumber
 {
-    if (phoneNumber == nil) {
-        return NO;
-    }
-
     NSString* value = [phoneNumber copy];
     return [self validateValue:&value error:nil];
 }

--- a/Source/Validation/ZMPhoneNumberValidator.m
+++ b/Source/Validation/ZMPhoneNumberValidator.m
@@ -85,4 +85,14 @@ ZM_EMPTY_ASSERTING_INIT()
     return YES;
 }
 
++ (BOOL)isValidPhoneNumber:(NSString *)phoneNumber
+{
+    if (phoneNumber == nil) {
+        return NO;
+    }
+
+    NSString* value = [phoneNumber copy];
+    return [self validateValue:&value error:nil];
+}
+
 @end

--- a/Tests/Source/Validation/ZMEmailAddressValidatorTests.m
+++ b/Tests/Source/Validation/ZMEmailAddressValidatorTests.m
@@ -77,13 +77,16 @@ static NSString * const domainValidCharactersLowercased = @"abcdefghijklmnopqrst
       };
     
     BOOL isValid;
+    BOOL isValidWithNonMutableCheck;
     NSError *error;
     NSMutableArray *validatedEmails = [NSMutableArray new];
     for (NSString *email in validEmailAddresses) {
         NSString *validatedEmail = email;
         isValid = [ZMEmailAddressValidator validateValue:&validatedEmail error:&error];
+        isValidWithNonMutableCheck = [ZMEmailAddressValidator isValidEmailAddress:validatedEmail];
         [validatedEmails addObject:validatedEmail];
         XCTAssertTrue(isValid);
+        XCTAssertTrue(isValidWithNonMutableCheck);
         XCTAssertNil(error);
     }
     AssertArraysContainsSameObjects(validatedEmails, validEmailAddresses.allValues);
@@ -124,11 +127,14 @@ static NSString * const domainValidCharactersLowercased = @"abcdefghijklmnopqrst
       ];
     
     BOOL isValid;
+    BOOL isValidWithNonMutableCheck;
     NSError *error;
     for (NSString *email in invalidEmailAddresses) {
         NSString *validatedEmail = email;
         isValid = [ZMEmailAddressValidator validateValue:&validatedEmail error:&error];
+        isValidWithNonMutableCheck = [ZMEmailAddressValidator isValidEmailAddress:validatedEmail];
         XCTAssertFalse(isValid, @"failed for %@", email);
+        XCTAssertFalse(isValidWithNonMutableCheck, @"isValidEmailAddress failed for %@", email);
         XCTAssertNotNil(error);
     }
 }

--- a/Tests/Source/Validation/ZMPhoneNumberValidatorTests.m
+++ b/Tests/Source/Validation/ZMPhoneNumberValidatorTests.m
@@ -51,11 +51,14 @@
       @""];
     
     BOOL isValid;
+    BOOL isValidWithNonMutableCheck;
     NSError *error;
     for (NSString *phoneNumber in validPhoneNumbers) {
         NSString *value = phoneNumber;
         isValid = [ZMPhoneNumberValidator validateValue:&value error:&error];
+        isValidWithNonMutableCheck = [ZMPhoneNumberValidator isValidPhoneNumber:value];
         XCTAssertTrue(value);
+        XCTAssertTrue(isValidWithNonMutableCheck);
         XCTAssertNil(error);
     }
 }
@@ -70,11 +73,14 @@
       ];
 
     BOOL isValid;
+    BOOL isValidWithNonMutableCheck;
     NSError *error;
     for (NSString *phoneNumber in invalidPhoneNumbers) {
         NSString *value = phoneNumber;
         isValid = [ZMPhoneNumberValidator validateValue:&value error:&error];
+        isValidWithNonMutableCheck = [ZMPhoneNumberValidator isValidPhoneNumber:value];
         XCTAssertFalse(isValid);
+        XCTAssertFalse(isValidWithNonMutableCheck);
         XCTAssertNotNil(error);
     }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

The phone number and email validators take a reference to an NSString pointer to check the validity of user input, and change the string when it can normalize it. 

While this may be useful in some cases, this API can be harder to use when we just want to check if text is valid without checking the updated value; especially in Swift where it is imported with an odd signature that does not return a Boolean value:

~~~swift
class func validateEmailAddress(_ ioEmailAddress: AutoreleasingUnsafeMutablePointer<NSString?>?) throws
~~~

For example, to check if an e-mail is valid, we'd need to write:

~~~swift
func isValidEmail(_ email: String?) -> Bool {
    var validationEmail: NSString? = email as NSString?

    do {
        try ZMEmailAddressValidator.validateEmailAddress(&validationEmail)
    } catch {
        return false
    }
}
~~~

### Solutions

We define helpers method on `ZMPhoneNumberValidator` and `ZMEmailAddressValidator` that provide a simpler API for checking the validity of user input.

New usage:

~~~swift
let emailValid: Bool = ZMEmailAddressValidator.isValidEmailAddress("alexis@wire.com")
let phoneValid: Bool = ZMPhoneNumberValidator.isValidPhoneNumber("+49 123 456 78969")
~~~