### PR TITLE
Add convenience init for IndexSet

### DIFF
--- a/Source/IndexSet+Helpers.swift
+++ b/Source/IndexSet+Helpers.swift
@@ -1,0 +1,34 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension IndexSet {
+    
+    public init(integersIn range: Range<IndexSet.Element>, excluding: [Range<IndexSet.Element>]) {
+        
+        var excludedIndexSet = IndexSet()
+        var includedIndexSet = IndexSet()
+        
+        excluding.forEach({ excludedIndexSet.insert(integersIn: $0) })
+        includedIndexSet.insert(integersIn: range)
+        
+        self = includedIndexSet.symmetricDifference(excludedIndexSet)
+    }
+    
+}

--- a/Tests/IndexSet+HelperTests.swift
+++ b/Tests/IndexSet+HelperTests.swift
@@ -1,0 +1,67 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+
+class IndexSet_HelperTests: XCTestCase {
+
+    override func setUp() {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testThatItExcludesARange() {
+        // given
+        let range = 0..<10
+        let excluded = [0..<5]
+        
+        // when
+        let sut = IndexSet(integersIn: range, excluding: excluded)
+        
+        // then
+        XCTAssertTrue(sut.contains(integersIn: IndexSet(arrayLiteral: 5, 6, 7, 8, 9)))
+    }
+    
+    func testThatItExcludesMultipleRanges() {
+        // given
+        let range = 0..<10
+        let excluded = [0..<5, 6..<10]
+        
+        // when
+        let sut = IndexSet(integersIn: range, excluding: excluded)
+        
+        // then
+        XCTAssertTrue(sut.contains(integersIn: IndexSet(arrayLiteral: 5)))
+    }
+    
+    func testThatItDiscardsRangesOutsideMainRange() {
+        // given
+        let range = 0..<10
+        let excluded = [6..<15]
+        
+        // when
+        let sut = IndexSet(integersIn: range, excluding: excluded)
+        
+        // then
+        XCTAssertTrue(sut.contains(integersIn: IndexSet(arrayLiteral: 0, 1, 2, 3, 4, 5)))
+    }
+
+}

--- a/WireUtilities.xcodeproj/project.pbxproj
+++ b/WireUtilities.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		163FB9081F22302C00802AF4 /* DispatchGroupQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163FB9071F22302C00802AF4 /* DispatchGroupQueue.swift */; };
 		163FB90C1F25EA0B00802AF4 /* DispatchGroupContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163FB90B1F25EA0B00802AF4 /* DispatchGroupContextTests.swift */; };
 		168B158C1F25F67600AB3C44 /* DispatchGroupQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 168B158B1F25F67600AB3C44 /* DispatchGroupQueueTests.swift */; };
+		16A5FDF7215A746B00AEEBBD /* IndexSet+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A5FDF6215A746B00AEEBBD /* IndexSet+Helpers.swift */; };
+		16A5FE05215A770000AEEBBD /* IndexSet+HelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A5FE04215A770000AEEBBD /* IndexSet+HelperTests.swift */; };
 		16D964DC1F79454000390417 /* SelfUnregisteringNotificationCenterToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D964DB1F79454000390417 /* SelfUnregisteringNotificationCenterToken.swift */; };
 		16EB9B361CE0D5A000883FCF /* NSString+MIMEType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16EB9B351CE0D5A000883FCF /* NSString+MIMEType.swift */; };
 		16EB9B381CE0D7D800883FCF /* NSString+MIMETypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16EB9B371CE0D7D800883FCF /* NSString+MIMETypeTests.swift */; };
@@ -252,6 +254,8 @@
 		163FB9071F22302C00802AF4 /* DispatchGroupQueue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DispatchGroupQueue.swift; sourceTree = "<group>"; };
 		163FB90B1F25EA0B00802AF4 /* DispatchGroupContextTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DispatchGroupContextTests.swift; sourceTree = "<group>"; };
 		168B158B1F25F67600AB3C44 /* DispatchGroupQueueTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DispatchGroupQueueTests.swift; sourceTree = "<group>"; };
+		16A5FDF6215A746B00AEEBBD /* IndexSet+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IndexSet+Helpers.swift"; sourceTree = "<group>"; };
+		16A5FE04215A770000AEEBBD /* IndexSet+HelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IndexSet+HelperTests.swift"; sourceTree = "<group>"; };
 		16D964DB1F79454000390417 /* SelfUnregisteringNotificationCenterToken.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SelfUnregisteringNotificationCenterToken.swift; sourceTree = "<group>"; };
 		16EB9B351CE0D5A000883FCF /* NSString+MIMEType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSString+MIMEType.swift"; sourceTree = "<group>"; };
 		16EB9B371CE0D7D800883FCF /* NSString+MIMETypeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSString+MIMETypeTests.swift"; sourceTree = "<group>"; };
@@ -540,6 +544,7 @@
 				091799631B7E04FE00E60DD9 /* ZMDeploymentEnvironment.m */,
 				F9FCE0A11C7DBBD00092BA68 /* ZMSwiftExceptionHandler.m */,
 				54181A4F1F594E4100155ABC /* FileManager+Move.swift */,
+				16A5FDF6215A746B00AEEBBD /* IndexSet+Helpers.swift */,
 				54181A531F594F6B00155ABC /* FileManager+Protection.swift */,
 				54181A551F594FD800155ABC /* FileManager+FileProtectionLock.swift */,
 				EECE922F1FFBC5540096387F /* FixedWidthInteger+Random.swift */,
@@ -717,6 +722,7 @@
 				0917996E1B7E2E4600E60DD9 /* ZMAPNSEnvironmentTests.m */,
 				0917996F1B7E2E4600E60DD9 /* ZMDeploymentEnvironmentTests.m */,
 				091799701B7E2E4600E60DD9 /* ZMMobileProvisionParserTests.m */,
+				16A5FE04215A770000AEEBBD /* IndexSet+HelperTests.swift */,
 				546E8A5B1B7503C6009EBA02 /* FunctionalTests.swift */,
 				163FB90B1F25EA0B00802AF4 /* DispatchGroupContextTests.swift */,
 				168B158B1F25F67600AB3C44 /* DispatchGroupQueueTests.swift */,
@@ -995,6 +1001,7 @@
 				3E88BE231B1F478200232589 /* NSURL+QueryComponents.m in Sources */,
 				3E88BE431B1F478200232589 /* ZMFunctional+noARC.m in Sources */,
 				BF9D0B091F1CF3F8005D4C31 /* Optional+Apply.swift in Sources */,
+				16A5FDF7215A746B00AEEBBD /* IndexSet+Helpers.swift in Sources */,
 				BF3C1B0D20DA7270001CE126 /* Equatable+OneOf.swift in Sources */,
 				F9FCE0A31C7DBBD00092BA68 /* ZMSwiftExceptionHandler.m in Sources */,
 				3E88BF631B1F68DC00232589 /* NSOperationQueue+Helpers.m in Sources */,
@@ -1073,6 +1080,7 @@
 				54181A521F594E6F00155ABC /* FileManager+MoveTests.swift in Sources */,
 				546E8A501B750146009EBA02 /* NSOperationQueue+HelpersTests.m in Sources */,
 				F9C9A7991CAEA8400039E10C /* ZMEncodedNSUUIDWithTimestampTests.m in Sources */,
+				16A5FE05215A770000AEEBBD /* IndexSet+HelperTests.swift in Sources */,
 				54C388AA1C4D5AF600A55C79 /* NSUUID+Type1Tests.swift in Sources */,
 				546E8A531B7501D0009EBA02 /* NSUUID+DataTests.m in Sources */,
 				5E7C6CC1214AA1A2004C30B5 /* AtomicIntegerTests.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

Add an `IndexSet` constructor for creating an index set from a range with a list of ranges excluded.
