### PR TITLE
Add method to normalize string for mention search

### DIFF
--- a/Source/NSString+Normalization.m
+++ b/Source/NSString+Normalization.m
@@ -45,6 +45,11 @@
     return string.removePunctuationCharacters;
 }
 
+- (instancetype)normalizedForMentionSearch
+{
+    return [self stringByFoldingWithOptions:NSCaseInsensitiveSearch | NSDiacriticInsensitiveSearch locale:nil];
+}
+
 - (instancetype)normalizedString;
 {
     NSString *string = [self normalizedEmailaddress];

--- a/Source/Public/NSString+Normalization.h
+++ b/Source/Public/NSString+Normalization.h
@@ -23,6 +23,7 @@
 
 - (instancetype)normalizedString;
 - (instancetype)normalizedForSearch;
+- (instancetype)normalizedForMentionSearch;
 - (instancetype)normalizedEmailaddress;
 
 - (BOOL)zmHasOnlyWhitespaceCharacters;

--- a/Tests/Source/NSString_NormalizationTests.m
+++ b/Tests/Source/NSString_NormalizationTests.m
@@ -152,4 +152,20 @@
     XCTAssertEqualObjects(normalizedString4, @"hey");
 }
 
+- (void)testThatItDoesNotRemovePunctuationCharacters_ForMentionSearch
+{
+    NSString *normalizedEmailaddress = [@"hêlló. wörld? wõrlds!..." normalizedForMentionSearch];
+    XCTAssertEqualObjects(normalizedEmailaddress, @"hello. world? worlds!...");
+    
+    NSString *normalizedString2 = [@"#hëy" normalizedForMentionSearch];
+    XCTAssertEqualObjects(normalizedString2, @"#hey");
+    
+    NSString *normalizedString3 = [@"@hēy" normalizedForMentionSearch];
+    XCTAssertEqualObjects(normalizedString3, @"@hey");
+    
+    NSString *normalizedString4 = [@"(hęy)" normalizedForMentionSearch];
+    XCTAssertEqualObjects(normalizedString4, @"(hey)");
+}
+
+
 @end


### PR DESCRIPTION
## What's new in this PR?

When searching users for creating a mention, we need to normalise the search strings but keep the punctuation. The existing method for normalising search strings removes punctuation after normalisation.