### PR TITLE
improve emoji detection logic and add test cases

### DIFF
--- a/Source/Public/String+Emoji.swift
+++ b/Source/Public/String+Emoji.swift
@@ -16,59 +16,72 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
+extension CharacterSet {
+    static let asciiPrintableSet = CharacterSet(charactersIn: "!\"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~")
+}
+
+extension Unicode.Scalar {
+    static let cancelTag: UInt32 = 0xE007F
+
+    var isEmojiComponentOrMiscSymbol: Bool {
+        switch self.value {
+        case 0x200D,       // Zero width joiner
+        0x2139,            // the info symobol
+        0x2030...0x2BFF,   // Misc symbols
+        0x2600...0x27BF,   // Misc symbols, Dingbats
+        Unicode.Scalar.cancelTag,
+        0xFE00...0xFE0F:   // Variation Selectors
+            return true
+        default:
+            return false
+        }
+    }
+
+
+    var isEmoji: Bool {
+        //Unicode General Category S* contains Sc, Sk, Sm & So, we just interest on So(5855 items)
+        return (CharacterSet.symbols.contains(self) && !CharacterSet.asciiPrintableSet.contains(self)) ||
+            self.isEmojiComponentOrMiscSymbol
+    }
+}
 
 extension String {
-
-    private enum Transform {
-        case toLatin, stripDiacritics, stripCombiningMarks, toUnicodeName
-
-        @available(iOS 9, *)
-        var stringTransform: StringTransform {
-            switch self {
-            case .toLatin: return .toLatin
-            case .stripDiacritics: return .stripDiacritics
-            case .stripCombiningMarks: return .stripCombiningMarks
-            case .toUnicodeName: return .toUnicodeName
-            }
-        }
-
-        var cfStringTransform: CFString {
-            switch self {
-            case .toLatin: return kCFStringTransformToLatin
-            case .stripDiacritics: return kCFStringTransformStripDiacritics
-            case .stripCombiningMarks: return kCFStringTransformStripCombiningMarks
-            case .toUnicodeName: return kCFStringTransformToUnicodeName
-            }
-        }
-    }
-
-    private func applying(transform: Transform) -> String? {
-        if #available(iOS 9, *) {
-            return applyingTransform(transform.stringTransform, reverse: false)
-        } else {
-            let ref = NSMutableString(string: self) as CFMutableString
-            CFStringTransform(ref, nil, transform.cfStringTransform, false)
-            return ref as String
-        }
-    }
-
-    static private var transforms: [Transform] {
-        return [
-            .toLatin,
-            .stripDiacritics,
-            .stripCombiningMarks
-        ]
-    }
-
-    private var normalized: String? {
-        return String.transforms.reduce(self) {
-            $0?.applying(transform: $1)
-        }
-    }
-
     public var containsEmoji: Bool {
-        let latinNormalized = normalized
-        return latinNormalized != latinNormalized?.applying(transform: .toUnicodeName)
+        guard count > 0 else { return false }
+
+        for char in self {
+            for scalar in char.unicodeScalars {
+                if scalar.isEmoji {
+                    return true
+                }
+            }
+        }
+
+        return false
     }
 
+    public var containsOnlyEmojiWithSpaces: Bool {
+        return components(separatedBy: .whitespaces).joined().containsOnlyEmoji
+    }
+
+    var containsOnlyEmoji: Bool {
+        guard count > 0 else { return false }
+
+        let cancelTag = Unicode.Scalar(Unicode.Scalar.cancelTag)!
+
+        for char in self {
+            // some national flags are combination of black flag and characters, and ends with Cancel Tag
+            if char.unicodeScalars.contains(cancelTag) {
+                continue
+            }
+
+            for scalar in char.unicodeScalars {
+                if !scalar.isEmoji {
+                    return false
+                }
+            }
+        }
+
+        return true
+    }
 }

--- a/Source/Validation/ZMPhoneNumberValidator.m
+++ b/Source/Validation/ZMPhoneNumberValidator.m
@@ -50,7 +50,7 @@ ZM_EMPTY_ASSERTING_INIT()
 
 + (BOOL)validateValue:(inout id *)ioPhoneNumber error:(out NSError **)outError
 {
-    if ([(*ioPhoneNumber) length] < 1) {
+    if ([(NSString *)(*ioPhoneNumber) length] < 1) {
         return YES;
     }
     

--- a/Tests/EmojiOnlyStringTests.swift
+++ b/Tests/EmojiOnlyStringTests.swift
@@ -1,0 +1,138 @@
+// 
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+// 
+
+
+import Foundation
+import XCTest
+
+class EmojiOnlyStringTests: XCTestCase {
+    
+    func testThatCommonEmojisAreDetected() {
+        // given
+        let commonEmoji = ["©️", "ℹ️", "☘️", "⏰️", "➰️", "♥️", "🀄️", "🇨🇭", "⭔", "⭕",
+                           "😜", "🙏", "🌝", "😘", "👍", "💩", "😂", "😍", "😁",
+                           "❤︎", "❤️", "🈚︎",  "🀄︎", //emoji variation
+                           "👩", "👩🏻", "👩🏼", "👩🏽", "👩🏾", "👩🏿", //Fitzpatrick modifiers
+                           "👨‍👩‍👧", "🏳️‍🌈", // Joining
+                           "🧘🏿‍♀️", "🧡", "🦒", "🧦", "🏴󠁧󠁢󠁷󠁬󠁳󠁿", "🧟‍♂️" ///Emoji 5.0
+        ]
+        
+        // then
+        commonEmoji.forEach {
+            XCTAssert($0.containsOnlyEmojiWithSpaces, "Failed: \($0)")
+            XCTAssert($0.containsEmoji, "Failed: \($0)")
+        }
+    }
+    
+    func testThatSeveralEmojisAreDetected() {
+        // given
+        let commonEmojiGroups = ["😜🙏🌝😘", "👍💩😂😍", "😁💁🙌", "👯😻"]
+        // then
+        commonEmojiGroups.forEach {
+            XCTAssertTrue($0.containsOnlyEmojiWithSpaces)
+        }
+    }
+    
+    func testThatSeveralEmojisWithSpacesAreDetected() {
+        // given
+        let commonEmojiGroups = ["😜      🙏 🌝 😘", "    👍💩😂😍", "😁💁🙌 ", "👯 😻"]
+        // then
+        commonEmojiGroups.forEach {
+            XCTAssertTrue($0.containsOnlyEmojiWithSpaces, "Failed: \($0)")
+        }
+    }
+    
+    func testThatNewEmojisAreDetected() {
+        // given
+        let newEmoji = ["💪🏾", "🤘🏼", "👶🏼", "💅🏼"]
+        // then
+        newEmoji.forEach {
+            XCTAssertTrue($0.containsOnlyEmojiWithSpaces, "Failed: \($0)")
+        }
+    }
+    
+    func testThatSeveralNewEmojisAreDetected() {
+        // given
+        let newEmojiGroups = ["💪🏾🤘🏼", "👶🏼💅🏼🤘🏼"]
+        // then
+        newEmojiGroups.forEach {
+            XCTAssertTrue($0.containsOnlyEmojiWithSpaces, "Failed: \($0)")
+        }
+    }
+    
+    func testThatSeveralNewEmojisWithSpacesAreDetected() {
+        // given
+        let newEmojiGroupsWithSpaces = [" 💪🏾🤘🏼", "👶🏼 💅🏼    🤘🏼 "]
+        // then
+        newEmojiGroupsWithSpaces.forEach {
+            XCTAssertTrue($0.containsOnlyEmojiWithSpaces, "Failed: \($0)")
+        }
+    }
+
+    func testThatASCIISymbolsAreNotDetected() {
+        // given
+        let langaugeStrings = ["=", "+", "$"]
+
+        // then
+        langaugeStrings.forEach {
+            XCTAssertFalse($0.containsOnlyEmojiWithSpaces, "\($0) has emojis")
+            XCTAssertFalse($0.containsEmoji, "\($0) contains emojis")
+        }
+    }
+
+    func testThatLangaugeStringIsNotDetected() {
+        // given
+        let langaugeStrings = ["ḀẀẶỳ", "ठःअठी३", "勺卉善爨", "Ёжик", "한국어",
+                               "ⰀⰁ", //Glagolitic, start from U0x2C0x, containsEmoji return true for this language
+                               //"⿆", //Kangxi Radicals, start from U0x2F0x it is not a emoji, but CharacterSet.symbols contains it.
+                               "はい",// Hiragana, start from U0x304x
+                               "ブ",// Katakana, start from U0x304x
+                               "ㄅㄆㄇ", //Bopomofo, start from U0x310x
+                               "Ⴀჟჯჰ", // Georgian, updated in uncodie 11.0
+                               "ქართული" // Georgian, updated in uncodie 11.0
+        ]
+        // then
+        langaugeStrings.forEach {
+            XCTAssertFalse($0.containsOnlyEmojiWithSpaces, "\($0) has emojis")
+            XCTAssertFalse($0.containsEmoji, "\($0) contains emojis")
+        }
+    }
+    
+    func testThatRTLStringIsNotDetected() {
+        // given
+        let rtlStrings = ["  באמת!‏"]
+        // then
+        rtlStrings.forEach {
+            XCTAssertFalse($0.containsOnlyEmojiWithSpaces)
+        }
+    }
+    
+    func testThatLanguageStringWithEmojiNotDetected() {
+        // given
+        let languageEmojiStrings = ["😜ḀẀẶỳ", "👯ठःअठी३", "👯勺卉善爨", "👯Ёжик"]
+        // then
+        languageEmojiStrings.forEach {
+            XCTAssertFalse($0.containsOnlyEmojiWithSpaces, "Failed: \($0)")
+            XCTAssert($0.containsEmoji)
+        }
+    }
+    
+    func testThatEmptyStringIsNotDetected() {
+        XCTAssertFalse("".containsOnlyEmojiWithSpaces)
+    }
+}

--- a/Tests/EmojiOnlyStringTests.swift
+++ b/Tests/EmojiOnlyStringTests.swift
@@ -1,20 +1,20 @@
-// 
+//
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
-// 
+// Copyright (C) 2018 Wire Swiss GmbH
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
+//
 
 
 import Foundation

--- a/Tests/String+EmojiTests.swift
+++ b/Tests/String+EmojiTests.swift
@@ -46,6 +46,15 @@ class String_EmojiTests: XCTestCase {
         XCTAssertFalse("الأشخاص المفضلين".containsEmoji)
     }
 
+    func testThatGlagoliticNotDetectedAsContainingEmoji() {
+        XCTAssertFalse("ⰀⰁ".containsEmoji)
+    }
+
+    func testThatGeorgianNotDetectedAsContainingEmoji() {
+        XCTAssertFalse("ქართული".containsEmoji)
+        XCTAssertFalse("Ⴀჟჯჰ".containsEmoji)
+    }
+
     func testThatNonLatinWithEmojiIsDetectedAsContainingEmoji() {
         XCTAssertTrue("الأشخاص المفضلين🙈".containsEmoji)
     }

--- a/WireUtilities.xcodeproj/project.pbxproj
+++ b/WireUtilities.xcodeproj/project.pbxproj
@@ -137,6 +137,7 @@
 		EECE92301FFBC5540096387F /* FixedWidthInteger+Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECE922F1FFBC5540096387F /* FixedWidthInteger+Random.swift */; };
 		EF18C7D21F9E37CA0085A832 /* String+Filename.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF18C7D11F9E37CA0085A832 /* String+Filename.swift */; };
 		EF18C7DA1F9E3D3B0085A832 /* String+FilenameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF18C7D91F9E3D3B0085A832 /* String+FilenameTests.swift */; };
+		EF638D7A2170E09B00344C8A /* EmojiOnlyStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF638D792170E09B00344C8A /* EmojiOnlyStringTests.swift */; };
 		F15BDB1E20889773002F36E8 /* TearDownCapable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15BDB1D20889772002F36E8 /* TearDownCapable.swift */; };
 		F1D567B1207BA40C00CCDD77 /* WireUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E88BD381B1F3EA300232589 /* WireUtilities.framework */; };
 		F1D567B5207BA50700CCDD77 /* WireUtilities.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3E88BD381B1F3EA300232589 /* WireUtilities.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -367,6 +368,7 @@
 		EECE922F1FFBC5540096387F /* FixedWidthInteger+Random.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FixedWidthInteger+Random.swift"; sourceTree = "<group>"; };
 		EF18C7D11F9E37CA0085A832 /* String+Filename.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Filename.swift"; sourceTree = "<group>"; };
 		EF18C7D91F9E3D3B0085A832 /* String+FilenameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+FilenameTests.swift"; sourceTree = "<group>"; };
+		EF638D792170E09B00344C8A /* EmojiOnlyStringTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = EmojiOnlyStringTests.swift; path = "../../wire-ios/Wire-iOS Tests/EmojiOnlyStringTests.swift"; sourceTree = "<group>"; };
 		F15BDB1D20889772002F36E8 /* TearDownCapable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TearDownCapable.swift; sourceTree = "<group>"; };
 		F1E148C0207BAECF00F81833 /* ios-test-host.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "ios-test-host.xcconfig"; sourceTree = "<group>"; };
 		F1E148C1207BAED000F81833 /* swift.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = swift.xcconfig; sourceTree = "<group>"; };
@@ -742,6 +744,7 @@
 				F9FCE0A41C7DBD180092BA68 /* ZMSwiftExceptionHandlerTests.m */,
 				54024FE71DF81CC6009BF6A0 /* DictionaryTests.swift */,
 				BFBAE9DC1E01A930003FCE49 /* String+EmojiTests.swift */,
+				EF638D792170E09B00344C8A /* EmojiOnlyStringTests.swift */,
 				BF3493F51EC36A6400B0C314 /* Iterator+ContainmentTests.swift */,
 				877F501E1E71B69C00894C90 /* String+ExtremeCombiningCharactersTests.swift */,
 				EF18C7D91F9E3D3B0085A832 /* String+FilenameTests.swift */,
@@ -1065,6 +1068,7 @@
 				F9D381AA1B70B91F00E6E4EB /* NSURL+QueryComponentsTest.m in Sources */,
 				F9FCE0A51C7DBD180092BA68 /* ZMSwiftExceptionHandlerTests.m in Sources */,
 				5E0A1FFC2105DE2700949B3E /* MapKeyPathTests.swift in Sources */,
+				EF638D7A2170E09B00344C8A /* EmojiOnlyStringTests.swift in Sources */,
 				F9D381AC1B70B92F00E6E4EB /* NSDate+ZMUTests.m in Sources */,
 				091799761B7E2E4D00E60DD9 /* ZMMobileProvisionParserTests.m in Sources */,
 				F9C9A78E1CAEA0110039E10C /* NSString_NormalizationTests.m in Sources */,

--- a/WireUtilities.xcodeproj/project.pbxproj
+++ b/WireUtilities.xcodeproj/project.pbxproj
@@ -137,7 +137,7 @@
 		EECE92301FFBC5540096387F /* FixedWidthInteger+Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECE922F1FFBC5540096387F /* FixedWidthInteger+Random.swift */; };
 		EF18C7D21F9E37CA0085A832 /* String+Filename.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF18C7D11F9E37CA0085A832 /* String+Filename.swift */; };
 		EF18C7DA1F9E3D3B0085A832 /* String+FilenameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF18C7D91F9E3D3B0085A832 /* String+FilenameTests.swift */; };
-		EF638D7A2170E09B00344C8A /* EmojiOnlyStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF638D792170E09B00344C8A /* EmojiOnlyStringTests.swift */; };
+		EF638D7C2170EDF000344C8A /* EmojiOnlyStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF638D7B2170EDF000344C8A /* EmojiOnlyStringTests.swift */; };
 		F15BDB1E20889773002F36E8 /* TearDownCapable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15BDB1D20889772002F36E8 /* TearDownCapable.swift */; };
 		F1D567B1207BA40C00CCDD77 /* WireUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E88BD381B1F3EA300232589 /* WireUtilities.framework */; };
 		F1D567B5207BA50700CCDD77 /* WireUtilities.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3E88BD381B1F3EA300232589 /* WireUtilities.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -368,7 +368,7 @@
 		EECE922F1FFBC5540096387F /* FixedWidthInteger+Random.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FixedWidthInteger+Random.swift"; sourceTree = "<group>"; };
 		EF18C7D11F9E37CA0085A832 /* String+Filename.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Filename.swift"; sourceTree = "<group>"; };
 		EF18C7D91F9E3D3B0085A832 /* String+FilenameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+FilenameTests.swift"; sourceTree = "<group>"; };
-		EF638D792170E09B00344C8A /* EmojiOnlyStringTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = EmojiOnlyStringTests.swift; path = "../../wire-ios/Wire-iOS Tests/EmojiOnlyStringTests.swift"; sourceTree = "<group>"; };
+		EF638D7B2170EDF000344C8A /* EmojiOnlyStringTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmojiOnlyStringTests.swift; sourceTree = "<group>"; };
 		F15BDB1D20889772002F36E8 /* TearDownCapable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TearDownCapable.swift; sourceTree = "<group>"; };
 		F1E148C0207BAECF00F81833 /* ios-test-host.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "ios-test-host.xcconfig"; sourceTree = "<group>"; };
 		F1E148C1207BAED000F81833 /* swift.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = swift.xcconfig; sourceTree = "<group>"; };
@@ -744,7 +744,7 @@
 				F9FCE0A41C7DBD180092BA68 /* ZMSwiftExceptionHandlerTests.m */,
 				54024FE71DF81CC6009BF6A0 /* DictionaryTests.swift */,
 				BFBAE9DC1E01A930003FCE49 /* String+EmojiTests.swift */,
-				EF638D792170E09B00344C8A /* EmojiOnlyStringTests.swift */,
+				EF638D7B2170EDF000344C8A /* EmojiOnlyStringTests.swift */,
 				BF3493F51EC36A6400B0C314 /* Iterator+ContainmentTests.swift */,
 				877F501E1E71B69C00894C90 /* String+ExtremeCombiningCharactersTests.swift */,
 				EF18C7D91F9E3D3B0085A832 /* String+FilenameTests.swift */,
@@ -1023,6 +1023,7 @@
 				54CA31291B74F36B00B820C0 /* Functional.swift in Sources */,
 				BF3493F41EC362D400B0C314 /* Iterator+Containment.swift in Sources */,
 				F9C9A78B1CAE9F9A0039E10C /* NSString+Normalization.m in Sources */,
+				EF638D7C2170EDF000344C8A /* EmojiOnlyStringTests.swift in Sources */,
 				163FB9061F2229DF00802AF4 /* DispatchGroupContext.swift in Sources */,
 				3E88BE1B1B1F478200232589 /* NSOrderedSet+Zeta.m in Sources */,
 				87B6489C2076078A002FC9E7 /* Composition.swift in Sources */,
@@ -1068,7 +1069,6 @@
 				F9D381AA1B70B91F00E6E4EB /* NSURL+QueryComponentsTest.m in Sources */,
 				F9FCE0A51C7DBD180092BA68 /* ZMSwiftExceptionHandlerTests.m in Sources */,
 				5E0A1FFC2105DE2700949B3E /* MapKeyPathTests.swift in Sources */,
-				EF638D7A2170E09B00344C8A /* EmojiOnlyStringTests.swift in Sources */,
 				F9D381AC1B70B92F00E6E4EB /* NSDate+ZMUTests.m in Sources */,
 				091799761B7E2E4D00E60DD9 /* ZMMobileProvisionParserTests.m in Sources */,
 				F9C9A78E1CAEA0110039E10C /* NSString_NormalizationTests.m in Sources */,


### PR DESCRIPTION
## What's new in this PR?

Move the emoji String extension from Wire-iOS (https://github.com/wireapp/wire-ios/pull/2787).

String.containsEmoji method is merged with revised logic and more test case for unicode 11.0 and ancient language are added.