### PR TITLE
Avoid force unwraps when checking if the file system is readable

### DIFF
--- a/Source/FileManager+FileProtectionLock.swift
+++ b/Source/FileManager+FileProtectionLock.swift
@@ -32,11 +32,11 @@ extension FileManager {
     public func isFileSystemAccessible() -> Bool {
         
         // create dummy file
-        let tempDir = self.urls(for: .cachesDirectory, in: .userDomainMask).first!
-        self.createAndProtectDirectory(at: tempDir)
-        let dummyFile = tempDir.appendingPathComponent("dummy_lock")
+        guard let cachesDirectory = self.urls(for: .cachesDirectory, in: .userDomainMask).first else { return false }
+        createAndProtectDirectory(at: cachesDirectory)
+        let dummyFile = cachesDirectory.appendingPathComponent("dummy_lock")
         let data = "testing".data(using: .utf8)!
-        try! data.write(to: dummyFile)
+        try? data.write(to: dummyFile)
         
         // protect until first unlock
         self.setProtectionUntilFirstUserAuthentication(dummyFile)


### PR DESCRIPTION
## What's new in this PR?

### Issues

We are seeing crashes in `isFileSystemAccessible` with `EXC_BREAKPOINT trap 5`. This is indication the system intentionally crashes due to a broken precondition (Force unwrap, unexpected nil).

https://rink.hockeyapp.net/manage/apps/42908/app_versions/1099/crash_reasons/243642663

### Causes

It's not clear from the stack trace exactly which line causes the crash but we do some force unwraps in that method.

### Solutions

Remove force unwraps.