### PR TITLE
Fix: Self profile screen: user name with Wales flag is shown as black flag and spaces

### DIFF
--- a/Source/Public/String+Emoji.swift
+++ b/Source/Public/String+Emoji.swift
@@ -20,10 +20,6 @@ extension CharacterSet {
     static let asciiPrintableSet = CharacterSet(charactersIn: "!\"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~")
 }
 
-extension UInt32 {
-    static let cancelTag: UInt32 = 0xE007F
-}
-
 extension Unicode.Scalar {
     static let cancelTag: Unicode.Scalar = Unicode.Scalar(UInt32.cancelTag)!
 
@@ -33,7 +29,7 @@ extension Unicode.Scalar {
         0x2139,            // the info symobol
         0x2030...0x2BFF,   // Misc symbols
         0x2600...0x27BF,   // Misc symbols, Dingbats
-        UInt32.cancelTag,
+        0xE007F,           // cancelTag
         0xFE00...0xFE0F:   // Variation Selectors
             return true
         default:

--- a/Source/Public/String+Emoji.swift
+++ b/Source/Public/String+Emoji.swift
@@ -20,8 +20,12 @@ extension CharacterSet {
     static let asciiPrintableSet = CharacterSet(charactersIn: "!\"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~")
 }
 
-extension Unicode.Scalar {
+extension UInt32 {
     static let cancelTag: UInt32 = 0xE007F
+}
+
+extension Unicode.Scalar {
+    static let cancelTag: Unicode.Scalar = Unicode.Scalar(UInt32.cancelTag)!
 
     var isEmojiComponentOrMiscSymbol: Bool {
         switch self.value {
@@ -29,7 +33,7 @@ extension Unicode.Scalar {
         0x2139,            // the info symobol
         0x2030...0x2BFF,   // Misc symbols
         0x2600...0x27BF,   // Misc symbols, Dingbats
-        Unicode.Scalar.cancelTag,
+        UInt32.cancelTag,
         0xFE00...0xFE0F:   // Variation Selectors
             return true
         default:
@@ -43,9 +47,21 @@ extension Unicode.Scalar {
         return (CharacterSet.symbols.contains(self) && !CharacterSet.asciiPrintableSet.contains(self)) ||
             self.isEmojiComponentOrMiscSymbol
     }
+    
 }
 
 extension String {
+    public func existsIn(characterSet: CharacterSet) -> Bool {
+        for char in self {
+            for scalar in char.unicodeScalars {
+                if characterSet.contains(scalar) {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
     public var containsEmoji: Bool {
         guard count > 0 else { return false }
 
@@ -64,10 +80,10 @@ extension String {
         return components(separatedBy: .whitespaces).joined().containsOnlyEmoji
     }
 
-    var containsOnlyEmoji: Bool {
+    public var containsOnlyEmoji: Bool {
         guard count > 0 else { return false }
 
-        let cancelTag = Unicode.Scalar(Unicode.Scalar.cancelTag)!
+        let cancelTag = Unicode.Scalar.cancelTag
 
         for char in self {
             // some national flags are combination of black flag and characters, and ends with Cancel Tag

--- a/Source/Public/String+Emoji.swift
+++ b/Source/Public/String+Emoji.swift
@@ -50,26 +50,35 @@ extension Unicode.Scalar {
     
 }
 
-extension String {
-    public func existsIn(characterSet: CharacterSet) -> Bool {
-        for char in self {
-            for scalar in char.unicodeScalars {
-                if characterSet.contains(scalar) {
-                    return true
-                }
+extension Character {
+    var isEmoji: Bool {
+        for scalar in self.unicodeScalars {
+            if scalar.isEmoji {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    public func contains(anyCharacterFrom characterSet: CharacterSet) -> Bool {
+        for scalar in self.unicodeScalars {
+            if characterSet.contains(scalar) {
+                return true
             }
         }
         return false
     }
 
+}
+
+extension String {
     public var containsEmoji: Bool {
         guard count > 0 else { return false }
 
         for char in self {
-            for scalar in char.unicodeScalars {
-                if scalar.isEmoji {
-                    return true
-                }
+            if char.isEmoji {
+                return true
             }
         }
 

--- a/Source/Public/String+Emoji.swift
+++ b/Source/Public/String+Emoji.swift
@@ -80,7 +80,7 @@ extension String {
         return components(separatedBy: .whitespaces).joined().containsOnlyEmoji
     }
 
-    public var containsOnlyEmoji: Bool {
+    var containsOnlyEmoji: Bool {
         guard count > 0 else { return false }
 
         let cancelTag = Unicode.Scalar.cancelTag

--- a/Source/Public/String+Emoji.swift
+++ b/Source/Public/String+Emoji.swift
@@ -21,7 +21,7 @@ extension CharacterSet {
 }
 
 extension Unicode.Scalar {
-    static let cancelTag: Unicode.Scalar = Unicode.Scalar(UInt32.cancelTag)!
+    static let cancelTag: Unicode.Scalar = Unicode.Scalar(0xE007F)!
 
     var isEmojiComponentOrMiscSymbol: Bool {
         switch self.value {

--- a/Source/Public/StringLengthValidator.swift
+++ b/Source/Public/StringLengthValidator.swift
@@ -51,8 +51,7 @@ import Foundation
         // check the trimmedString contains controlSet characters and replace matchings with spaces
 
         trimmedString = trimmedString
-            .map{ String($0) }
-            .map{ $0.containsOnlyEmoji || !$0.existsIn(characterSet: controlSet) ? $0 : " " }
+            .map{ $0.isEmoji || !$0.contains(anyCharacterFrom: controlSet) ? String($0) : " " }
             .joined()
 
         if trimmedString.count < minimumStringLength {

--- a/Source/Public/StringLengthValidator.swift
+++ b/Source/Public/StringLengthValidator.swift
@@ -48,21 +48,12 @@ import Foundation
 
         var trimmedString = string.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        var filteredString = ""
+        // check the trimmedString contains controlSet characters and replace matchings with spaces
 
-        let startIndex = trimmedString.startIndex
-        for i in 0..<trimmedString.count {
-            let index = trimmedString.index(startIndex, offsetBy: i)
-
-            let singleChar = String(trimmedString[index])
-            if singleChar.containsOnlyEmoji || !singleChar.existsIn(characterSet: controlSet) {
-                filteredString += singleChar
-            } else {
-                filteredString += " "
-            }
-        }
-
-        trimmedString = filteredString
+        trimmedString = trimmedString
+            .map{ String($0)}
+            .map{$0.containsOnlyEmoji || !$0.existsIn(characterSet: controlSet) ? $0 : " "}
+            .joined()
 
         if trimmedString.count < minimumStringLength {
             throw StringLengthError.tooShort

--- a/Source/Public/StringLengthValidator.swift
+++ b/Source/Public/StringLengthValidator.swift
@@ -51,8 +51,8 @@ import Foundation
         // check the trimmedString contains controlSet characters and replace matchings with spaces
 
         trimmedString = trimmedString
-            .map{ String($0)}
-            .map{$0.containsOnlyEmoji || !$0.existsIn(characterSet: controlSet) ? $0 : " "}
+            .map{ String($0) }
+            .map{ $0.containsOnlyEmoji || !$0.existsIn(characterSet: controlSet) ? $0 : " " }
             .joined()
 
         if trimmedString.count < minimumStringLength {

--- a/Source/Public/StringLengthValidator.swift
+++ b/Source/Public/StringLengthValidator.swift
@@ -45,13 +45,25 @@ import Foundation
         guard let string = ioValue.pointee as? String else {
             throw StringLengthError.tooShort
         }
-        
+
         var trimmedString = string.trimmingCharacters(in: .whitespacesAndNewlines)
-        
-        while let range = trimmedString.rangeOfCharacter(from: controlSet) {
-            trimmedString.replaceSubrange(range, with: " ")
+
+        var filteredString = ""
+
+        let startIndex = trimmedString.startIndex
+        for i in 0..<trimmedString.count {
+            let index = trimmedString.index(startIndex, offsetBy: i)
+
+            let singleChar = String(trimmedString[index])
+            if singleChar.containsOnlyEmoji || !singleChar.existsIn(characterSet: controlSet) {
+                filteredString += singleChar
+            } else {
+                filteredString += " "
+            }
         }
-        
+
+        trimmedString = filteredString
+
         if trimmedString.count < minimumStringLength {
             throw StringLengthError.tooShort
         }

--- a/Tests/EmojiOnlyStringTests.swift
+++ b/Tests/EmojiOnlyStringTests.swift
@@ -29,9 +29,10 @@ class EmojiOnlyStringTests: XCTestCase {
                            "❤︎", "❤️", "🈚︎",  "🀄︎", //emoji variation
                            "👩", "👩🏻", "👩🏼", "👩🏽", "👩🏾", "👩🏿", //Fitzpatrick modifiers
                            "👨‍👩‍👧", "🏳️‍🌈", // Joining
-                           "🧘🏿‍♀️", "🧡", "🦒", "🧦", "🏴󠁧󠁢󠁷󠁬󠁳󠁿", "🧟‍♂️" ///Emoji 5.0
+                           "🧘🏿‍♀️", "🧡", "🦒", "🧦", "🏴󠁧󠁢󠁷󠁬󠁳󠁿", "🧟‍♂️", ///Emoji 5.0
+            //                           "🥮" // TODO: Emoji 11.0, first support in iOS 12.1
         ]
-        
+
         // then
         commonEmoji.forEach {
             XCTAssert($0.containsOnlyEmojiWithSpaces, "Failed: \($0)")
@@ -99,12 +100,14 @@ class EmojiOnlyStringTests: XCTestCase {
         // given
         let langaugeStrings = ["ḀẀẶỳ", "ठःअठी३", "勺卉善爨", "Ёжик", "한국어",
                                "ⰀⰁ", //Glagolitic, start from U0x2C0x, containsEmoji return true for this language
-                               //"⿆", //Kangxi Radicals, start from U0x2F0x it is not a emoji, but CharacterSet.symbols contains it.
-                               "はい",// Hiragana, start from U0x304x
-                               "ブ",// Katakana, start from U0x304x
-                               "ㄅㄆㄇ", //Bopomofo, start from U0x310x
-                               "Ⴀჟჯჰ", // Georgian, updated in uncodie 11.0
-                               "ქართული" // Georgian, updated in uncodie 11.0
+            //"⿆", //Kangxi Radicals, start from U0x2F0x it is not a emoji, but CharacterSet.symbols contains it.
+            "はい",// Hiragana, start from U0x304x
+            "ブ",// Katakana, start from U0x304x
+            "ㄅㄆㄇ", //Bopomofo, start from U0x310x
+            "Ⴀჟჯჰ", // Georgian, updated in uncodie 11.0
+            "ქართული", // Georgian, updated in uncodie 11.0
+            " Α α, Β β, Γ γ, Δ δ, Ε ε, Ζ ζ, Η η, Θ θ, Ι ι, Κ κ, Λ λ, Μ μ, Ν ν, Ξ ξ, Ο ο, Π π, Ρ ρ, Σ σ/ς, Τ τ, Υ υ, Φ φ, Χ χ, Ψ ψ, Ω ω.", //Greek
+            "。，？！" // Chinese punctuation marks
         ]
         // then
         langaugeStrings.forEach {

--- a/Tests/EmojiOnlyStringTests.swift
+++ b/Tests/EmojiOnlyStringTests.swift
@@ -30,7 +30,7 @@ class EmojiOnlyStringTests: XCTestCase {
                            "👩", "👩🏻", "👩🏼", "👩🏽", "👩🏾", "👩🏿", //Fitzpatrick modifiers
                            "👨‍👩‍👧", "🏳️‍🌈", // Joining
                            "🧘🏿‍♀️", "🧡", "🦒", "🧦", "🏴󠁧󠁢󠁷󠁬󠁳󠁿", "🧟‍♂️", ///Emoji 5.0
-            //                           "🥮" // TODO: Emoji 11.0, first support in iOS 12.1
+            // TODO: Test for Emoji 11.0 new emoji "🥮" after iOS 12.1 is released
         ]
 
         // then
@@ -98,9 +98,10 @@ class EmojiOnlyStringTests: XCTestCase {
 
     func testThatLangaugeStringIsNotDetected() {
         // given
+
+        //Notice: "⿆" - Kangxi Radicals, start from U0x2F0x it is not a emoji, but CharacterSet.symbols contains it.
         let langaugeStrings = ["ḀẀẶỳ", "ठःअठी३", "勺卉善爨", "Ёжик", "한국어",
                                "ⰀⰁ", //Glagolitic, start from U0x2C0x, containsEmoji return true for this language
-            //"⿆", //Kangxi Radicals, start from U0x2F0x it is not a emoji, but CharacterSet.symbols contains it.
             "はい",// Hiragana, start from U0x304x
             "ブ",// Katakana, start from U0x304x
             "ㄅㄆㄇ", //Bopomofo, start from U0x310x

--- a/Tests/Source/Validation/StringLengthValidator.swift
+++ b/Tests/Source/Validation/StringLengthValidator.swift
@@ -1,0 +1,37 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+
+class StringLengthValidatorTests: XCTestCase {
+    func testThatUnicode11EmojiPassesValidation() {
+        let originalValue = "🏴󠁧󠁢󠁷󠁬󠁳󠁿"
+        var value: AnyObject? = originalValue as AnyObject?
+        var error: Error?
+
+        do {
+            try StringLengthValidator.validateValue(&value, minimumStringLength: 1, maximumStringLength: 64, maximumByteLength: 100)
+        }
+        catch let err {
+            error = err
+        }
+
+        XCTAssertNil(error)
+        XCTAssertEqual(originalValue, value! as! String)
+    }
+}

--- a/Tests/Source/Validation/StringLengthValidatorTests.swift
+++ b/Tests/Source/Validation/StringLengthValidatorTests.swift
@@ -19,7 +19,7 @@
 import XCTest
 
 class StringLengthValidatorTests: XCTestCase {
-    func testThatUnicode11EmojiPassesValidation() {
+    func testThatUnicode5EmojiContainsTagsPassesValidation() {
         let originalValue = "🏴󠁧󠁢󠁷󠁬󠁳󠁿"
         var value: AnyObject? = originalValue as AnyObject?
         var error: Error?

--- a/WireUtilities.xcodeproj/project.pbxproj
+++ b/WireUtilities.xcodeproj/project.pbxproj
@@ -138,7 +138,7 @@
 		EF18C7D21F9E37CA0085A832 /* String+Filename.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF18C7D11F9E37CA0085A832 /* String+Filename.swift */; };
 		EF18C7DA1F9E3D3B0085A832 /* String+FilenameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF18C7D91F9E3D3B0085A832 /* String+FilenameTests.swift */; };
 		EFC0C7B021772E6200380C4B /* EmojiOnlyStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF638D7B2170EDF000344C8A /* EmojiOnlyStringTests.swift */; };
-		EFD003562179FABC008C20D3 /* StringLengthValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFD003552179FABC008C20D3 /* StringLengthValidator.swift */; };
+		EFD003562179FABC008C20D3 /* StringLengthValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFD003552179FABC008C20D3 /* StringLengthValidatorTests.swift */; };
 		F15BDB1E20889773002F36E8 /* TearDownCapable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15BDB1D20889772002F36E8 /* TearDownCapable.swift */; };
 		F1D567B1207BA40C00CCDD77 /* WireUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E88BD381B1F3EA300232589 /* WireUtilities.framework */; };
 		F1D567B5207BA50700CCDD77 /* WireUtilities.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3E88BD381B1F3EA300232589 /* WireUtilities.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -370,7 +370,7 @@
 		EF18C7D11F9E37CA0085A832 /* String+Filename.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Filename.swift"; sourceTree = "<group>"; };
 		EF18C7D91F9E3D3B0085A832 /* String+FilenameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+FilenameTests.swift"; sourceTree = "<group>"; };
 		EF638D7B2170EDF000344C8A /* EmojiOnlyStringTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmojiOnlyStringTests.swift; sourceTree = "<group>"; };
-		EFD003552179FABC008C20D3 /* StringLengthValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringLengthValidator.swift; sourceTree = "<group>"; };
+		EFD003552179FABC008C20D3 /* StringLengthValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringLengthValidatorTests.swift; sourceTree = "<group>"; };
 		F15BDB1D20889772002F36E8 /* TearDownCapable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TearDownCapable.swift; sourceTree = "<group>"; };
 		F1E148C0207BAECF00F81833 /* ios-test-host.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "ios-test-host.xcconfig"; sourceTree = "<group>"; };
 		F1E148C1207BAED000F81833 /* swift.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = swift.xcconfig; sourceTree = "<group>"; };
@@ -698,7 +698,7 @@
 				F9C9A7C11CAEAFE10039E10C /* ZMEmailAddressValidatorTests.m */,
 				F9C9A7C21CAEAFE10039E10C /* ZMPhoneNumberValidatorTests.m */,
 				F9C9A7C31CAEAFE10039E10C /* ZMStringLengthValidatorTests.m */,
-				EFD003552179FABC008C20D3 /* StringLengthValidator.swift */,
+				EFD003552179FABC008C20D3 /* StringLengthValidatorTests.swift */,
 			);
 			name = Validation;
 			path = Source/Validation;
@@ -1088,7 +1088,7 @@
 				546E8A501B750146009EBA02 /* NSOperationQueue+HelpersTests.m in Sources */,
 				F9C9A7991CAEA8400039E10C /* ZMEncodedNSUUIDWithTimestampTests.m in Sources */,
 				16A5FE05215A770000AEEBBD /* IndexSet+HelperTests.swift in Sources */,
-				EFD003562179FABC008C20D3 /* StringLengthValidator.swift in Sources */,
+				EFD003562179FABC008C20D3 /* StringLengthValidatorTests.swift in Sources */,
 				54C388AA1C4D5AF600A55C79 /* NSUUID+Type1Tests.swift in Sources */,
 				546E8A531B7501D0009EBA02 /* NSUUID+DataTests.m in Sources */,
 				5E7C6CC1214AA1A2004C30B5 /* AtomicIntegerTests.swift in Sources */,

--- a/WireUtilities.xcodeproj/project.pbxproj
+++ b/WireUtilities.xcodeproj/project.pbxproj
@@ -138,6 +138,7 @@
 		EF18C7D21F9E37CA0085A832 /* String+Filename.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF18C7D11F9E37CA0085A832 /* String+Filename.swift */; };
 		EF18C7DA1F9E3D3B0085A832 /* String+FilenameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF18C7D91F9E3D3B0085A832 /* String+FilenameTests.swift */; };
 		EFC0C7B021772E6200380C4B /* EmojiOnlyStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF638D7B2170EDF000344C8A /* EmojiOnlyStringTests.swift */; };
+		EFD003562179FABC008C20D3 /* StringLengthValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFD003552179FABC008C20D3 /* StringLengthValidator.swift */; };
 		F15BDB1E20889773002F36E8 /* TearDownCapable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15BDB1D20889772002F36E8 /* TearDownCapable.swift */; };
 		F1D567B1207BA40C00CCDD77 /* WireUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E88BD381B1F3EA300232589 /* WireUtilities.framework */; };
 		F1D567B5207BA50700CCDD77 /* WireUtilities.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3E88BD381B1F3EA300232589 /* WireUtilities.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -369,6 +370,7 @@
 		EF18C7D11F9E37CA0085A832 /* String+Filename.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Filename.swift"; sourceTree = "<group>"; };
 		EF18C7D91F9E3D3B0085A832 /* String+FilenameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+FilenameTests.swift"; sourceTree = "<group>"; };
 		EF638D7B2170EDF000344C8A /* EmojiOnlyStringTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmojiOnlyStringTests.swift; sourceTree = "<group>"; };
+		EFD003552179FABC008C20D3 /* StringLengthValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringLengthValidator.swift; sourceTree = "<group>"; };
 		F15BDB1D20889772002F36E8 /* TearDownCapable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TearDownCapable.swift; sourceTree = "<group>"; };
 		F1E148C0207BAECF00F81833 /* ios-test-host.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "ios-test-host.xcconfig"; sourceTree = "<group>"; };
 		F1E148C1207BAED000F81833 /* swift.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = swift.xcconfig; sourceTree = "<group>"; };
@@ -696,6 +698,7 @@
 				F9C9A7C11CAEAFE10039E10C /* ZMEmailAddressValidatorTests.m */,
 				F9C9A7C21CAEAFE10039E10C /* ZMPhoneNumberValidatorTests.m */,
 				F9C9A7C31CAEAFE10039E10C /* ZMStringLengthValidatorTests.m */,
+				EFD003552179FABC008C20D3 /* StringLengthValidator.swift */,
 			);
 			name = Validation;
 			path = Source/Validation;
@@ -1085,6 +1088,7 @@
 				546E8A501B750146009EBA02 /* NSOperationQueue+HelpersTests.m in Sources */,
 				F9C9A7991CAEA8400039E10C /* ZMEncodedNSUUIDWithTimestampTests.m in Sources */,
 				16A5FE05215A770000AEEBBD /* IndexSet+HelperTests.swift in Sources */,
+				EFD003562179FABC008C20D3 /* StringLengthValidator.swift in Sources */,
 				54C388AA1C4D5AF600A55C79 /* NSUUID+Type1Tests.swift in Sources */,
 				546E8A531B7501D0009EBA02 /* NSUUID+DataTests.m in Sources */,
 				5E7C6CC1214AA1A2004C30B5 /* AtomicIntegerTests.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Issues

Self-profile screen: username with Wales flag is shown as black flag and spaces

### Causes

StringLengthValidator replaces all Unicode 5.0 Tags with spaces, which are part of a complete emoji.

### Solutions

Check every Character in the String is an emoji and not a character in controlSet.
