### PR TITLE
Fix: App crashes performing EmoticonSubstitution

### DIFF
--- a/Source/IndexSet+Helpers.swift
+++ b/Source/IndexSet+Helpers.swift
@@ -28,7 +28,7 @@ extension IndexSet {
         excluding.forEach({ excludedIndexSet.insert(integersIn: $0) })
         includedIndexSet.insert(integersIn: range)
         
-        self = includedIndexSet.symmetricDifference(excludedIndexSet)
+        self = includedIndexSet.subtracting(excludedIndexSet)
     }
     
 }

--- a/Tests/IndexSet+HelperTests.swift
+++ b/Tests/IndexSet+HelperTests.swift
@@ -38,6 +38,7 @@ class IndexSet_HelperTests: XCTestCase {
         
         // then
         XCTAssertTrue(sut.contains(integersIn: IndexSet(arrayLiteral: 5, 6, 7, 8, 9)))
+        XCTAssertFalse(sut.contains(integersIn: IndexSet(arrayLiteral: 0, 10)))
     }
     
     func testThatItExcludesMultipleRanges() {
@@ -61,7 +62,12 @@ class IndexSet_HelperTests: XCTestCase {
         let sut = IndexSet(integersIn: range, excluding: excluded)
         
         // then
-        XCTAssertTrue(sut.contains(integersIn: IndexSet(arrayLiteral: 0, 1, 2, 3, 4, 5)))
+        XCTAssert(sut.count == 6)
+
+        XCTAssert(sut.contains(integersIn: IndexSet(arrayLiteral: 0, 1, 2, 3, 4, 5)))
+
+        XCTAssertFalse(sut.contains(integersIn: IndexSet(arrayLiteral: 9)))
+        XCTAssertFalse(sut.contains(integersIn: IndexSet(arrayLiteral: 10)))
     }
 
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

App crashes when performing EmoticonSubstitution.

### Causes

The logic of IndexSet's init(integersIn range: Range<IndexSet.Element>, excluding: [Range<IndexSet.Element>]) method returns out of the bound.

### Solutions

Fix the logic, use subtracting instead of symmetricDifference.

## Notes

- [ ] Move the related NSMutableAttributedString methods from Wire-iOS to Wire-iOS-Utilities
