### PR TITLE
Add helpers for type-erased properties

### DIFF
--- a/Source/AnyProperty.swift
+++ b/Source/AnyProperty.swift
@@ -1,0 +1,82 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+/**
+ * A wrapper that can be used to access a property inside a type-erased box.
+ *
+ * You typically create this wrapper by passing the object of the type you want
+ * to erase, and the key path to the property you want to access inside the box.
+ *
+ * When you want to access the value, call the `getter()` block.
+ */
+
+public struct AnyConstantProperty<Value> {
+
+    /// The block that returns the value from the erased object.
+    public let getter: () -> Value
+
+    /**
+     * Creates the type-erased accessor for a property inside another object.
+     * - parameter base: The object that contains the property.
+     * - parameter keyPath: The key path to the value.
+     * - note: The `base` object will be retained by the box.
+     */
+
+    public init<Base>(_ base: Base, keyPath: Swift.KeyPath<Base, Value>) {
+        getter = {
+            return base[keyPath: keyPath]
+        }
+    }
+}
+
+/**
+ * A wrapper that can be used to get and set a property inside a type-erased box.
+ *
+ * You typically create this wrapper by passing the object of the type you want
+ * to erase, and the key path to the property you want to access inside the box.
+ *
+ * When you want to get the value, call the `getter()` block. When you want to change
+ * the value in the type-erased value, call the `setter()` block with the new value.
+ */
+
+public struct AnyMutableProperty<Value> {
+    /// The block that returns the value from the erased object.
+    public let getter: () -> Value
+
+    /// The block that changes the value inside the erased object.
+    public let setter: (Value) -> Void
+
+    /**
+     * Creates the type-erased accessor for a mutable property inside another object.
+     * - parameter base: The object that contains the property.
+     * - parameter keyPath: The key path to the value.
+     * - note: The `base` object will be retained by the box.
+     */
+
+    public init<Base>(_ base: Base, keyPath: ReferenceWritableKeyPath<Base, Value>) {
+        getter = {
+            return base[keyPath: keyPath]
+        }
+
+        setter = { newValue in
+            base[keyPath: keyPath] = newValue
+        }
+    }
+}

--- a/Tests/AnyPropertyTests.swift
+++ b/Tests/AnyPropertyTests.swift
@@ -1,0 +1,125 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+import WireUtilities
+
+// MARK: Type Erased Scenario
+
+protocol Message: class {
+    associatedtype Content
+    var content: Content { get set }
+    var sender: String { get }
+    var numberOfLikes: Int { get set }
+}
+
+class TextMessage: Message {
+    var content: String
+    let sender: String
+    var numberOfLikes: Int = 0
+
+    init(content: String, sender: String) {
+        self.content = content
+        self.sender = sender
+    }
+}
+
+class ImageMessage: Message {
+    var content: UIImage
+    let sender: String
+    var numberOfLikes: Int = 0
+
+    init(content: UIImage, sender: String) {
+        self.content = content
+        self.sender = sender
+    }
+}
+
+class AnyMessage {
+    private let _sender: AnyConstantProperty<String>
+    private let _numberOfLikes: AnyMutableProperty<Int>
+
+    init<T: Message>(_ message: T) {
+        _sender = AnyConstantProperty(message, keyPath: \.sender)
+        _numberOfLikes = AnyMutableProperty(message, keyPath: \.numberOfLikes)
+    }
+
+    var sender: String {
+        return _sender.getter()
+    }
+
+    var numberOfLikes: Int {
+        get { return _numberOfLikes.getter() }
+        set { _numberOfLikes.setter(newValue) }
+    }
+}
+
+// MARK: - Tests
+
+class AnyPropertyTests: XCTestCase {
+
+    var textMessage: TextMessage!
+    var imageMessage: ImageMessage!
+
+    override func setUp() {
+        super.setUp()
+        textMessage = TextMessage(content: "Hello", sender: "User A")
+        imageMessage = ImageMessage(content: UIImage(), sender: "User B")
+    }
+
+    override func tearDown() {
+        textMessage = nil
+        imageMessage = nil
+        super.tearDown()
+    }
+
+    func testThatItCanReadConstantProperty() {
+        // GIVEN
+        let firstMessage = AnyMessage(textMessage)
+        let lastMessage = AnyMessage(imageMessage)
+
+        // THEN
+        XCTAssertEqual(firstMessage.sender, textMessage.sender)
+        XCTAssertEqual(lastMessage.sender, imageMessage.sender)
+    }
+
+    func testThatItCanReadMutableProperty() {
+        // GIVEN
+        let firstMessage = AnyMessage(textMessage)
+        let lastMessage = AnyMessage(imageMessage)
+
+        // THEN
+        XCTAssertEqual(firstMessage.numberOfLikes, 0)
+        XCTAssertEqual(lastMessage.numberOfLikes, 0)
+    }
+
+    func testThatItCanChangeMutableProperty() {
+        // GIVEN
+        let firstMessage = AnyMessage(textMessage)
+        let lastMessage = AnyMessage(imageMessage)
+
+        // WHEN
+        firstMessage.numberOfLikes = 10
+        lastMessage.numberOfLikes += 5
+
+        // THEN
+        XCTAssertEqual(firstMessage.numberOfLikes, 10)
+        XCTAssertEqual(lastMessage.numberOfLikes, 5)
+    }
+
+}

--- a/WireUtilities.xcodeproj/project.pbxproj
+++ b/WireUtilities.xcodeproj/project.pbxproj
@@ -92,6 +92,8 @@
 		54FA8E821BC6CC3400E42980 /* NSData+ZMSCryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54FA8E811BC6CC3400E42980 /* NSData+ZMSCryptoTests.swift */; };
 		5E0A1FF92105DBBA00949B3E /* Map+KeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0A1FF82105DBBA00949B3E /* Map+KeyPath.swift */; };
 		5E0A1FFC2105DE2700949B3E /* MapKeyPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0A1FFA2105DE2100949B3E /* MapKeyPathTests.swift */; };
+		5E4BC1BC2189E6A400A8682E /* AnyProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E4BC1BB2189E6A400A8682E /* AnyProperty.swift */; };
+		5E4BC1BE2189EA3900A8682E /* AnyPropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E4BC1BD2189EA3900A8682E /* AnyPropertyTests.swift */; };
 		5E7C6CC1214AA1A2004C30B5 /* AtomicIntegerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C6CBF214AA197004C30B5 /* AtomicIntegerTests.swift */; };
 		5EE020C6214A9FC5001669F0 /* ZMAtomicInteger.h in Headers */ = {isa = PBXBuildFile; fileRef = 5EE020C4214A9FC5001669F0 /* ZMAtomicInteger.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5EE020C7214A9FC5001669F0 /* ZMAtomicInteger.m in Sources */ = {isa = PBXBuildFile; fileRef = 5EE020C5214A9FC5001669F0 /* ZMAtomicInteger.m */; };
@@ -326,6 +328,8 @@
 		54FA8E811BC6CC3400E42980 /* NSData+ZMSCryptoTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "NSData+ZMSCryptoTests.swift"; path = "Source/NSData+ZMSCryptoTests.swift"; sourceTree = "<group>"; };
 		5E0A1FF82105DBBA00949B3E /* Map+KeyPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Map+KeyPath.swift"; sourceTree = "<group>"; };
 		5E0A1FFA2105DE2100949B3E /* MapKeyPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapKeyPathTests.swift; sourceTree = "<group>"; };
+		5E4BC1BB2189E6A400A8682E /* AnyProperty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyProperty.swift; sourceTree = "<group>"; };
+		5E4BC1BD2189EA3900A8682E /* AnyPropertyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyPropertyTests.swift; sourceTree = "<group>"; };
 		5E7C6CBF214AA197004C30B5 /* AtomicIntegerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicIntegerTests.swift; sourceTree = "<group>"; };
 		5EE020C4214A9FC5001669F0 /* ZMAtomicInteger.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ZMAtomicInteger.h; sourceTree = "<group>"; };
 		5EE020C5214A9FC5001669F0 /* ZMAtomicInteger.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ZMAtomicInteger.m; sourceTree = "<group>"; };
@@ -554,6 +558,7 @@
 				EECE922F1FFBC5540096387F /* FixedWidthInteger+Random.swift */,
 				5EE020C4214A9FC5001669F0 /* ZMAtomicInteger.h */,
 				5EE020C5214A9FC5001669F0 /* ZMAtomicInteger.m */,
+				5E4BC1BB2189E6A400A8682E /* AnyProperty.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -755,6 +760,7 @@
 				54181A571F59516600155ABC /* FileManager+ProtectionTests.swift */,
 				5E0A1FFA2105DE2100949B3E /* MapKeyPathTests.swift */,
 				5E7C6CBF214AA197004C30B5 /* AtomicIntegerTests.swift */,
+				5E4BC1BD2189EA3900A8682E /* AnyPropertyTests.swift */,
 			);
 			name = Source;
 			sourceTree = "<group>";
@@ -994,6 +1000,7 @@
 				3E88BE3D1B1F478200232589 /* ZMDebugHelpers.m in Sources */,
 				091799531B7DFA1500E60DD9 /* ZMMobileProvisionParser.m in Sources */,
 				3E88BF451B1F66B100232589 /* NSUUID+Data.m in Sources */,
+				5E4BC1BC2189E6A400A8682E /* AnyProperty.swift in Sources */,
 				54CA313B1B74F36B00B820C0 /* Sets.swift in Sources */,
 				D5D65A13207631A100D7F3C3 /* NSManagedObjectContext+PerformGrouped.swift in Sources */,
 				87ECBDD51E78457C00596836 /* ExtremeCombiningCharactersValidator.swift in Sources */,
@@ -1087,6 +1094,7 @@
 				54181A521F594E6F00155ABC /* FileManager+MoveTests.swift in Sources */,
 				546E8A501B750146009EBA02 /* NSOperationQueue+HelpersTests.m in Sources */,
 				F9C9A7991CAEA8400039E10C /* ZMEncodedNSUUIDWithTimestampTests.m in Sources */,
+				5E4BC1BE2189EA3900A8682E /* AnyPropertyTests.swift in Sources */,
 				16A5FE05215A770000AEEBBD /* IndexSet+HelperTests.swift in Sources */,
 				EFD003562179FABC008C20D3 /* StringLengthValidatorTests.swift in Sources */,
 				54C388AA1C4D5AF600A55C79 /* NSUUID+Type1Tests.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Issues

When creating type-erased wrappers for generic objects, we frequently need to read and write properties. 

The most common approach is to manually generate a getter and a setter for the property in the initializer of the box, when we still have access to the typed object we want to erase.

~~~swift
class AnyMessage {
    private let likesGetter: () -> Int
    private let likesSetter: (Int) -> Void

    init<T: Message>(_ message: T) {
        likesGetter = {
            return message.likes
        }

        likesSetter = {
            return message.likes = newValue
        }
    }

    var likes: Int {
        get { return likesGetter() }
        set { likesSetter(newValue) }
    }
}
~~~

This is a tedious method that doesn't scale well when the base protocol we are wrapping is getting multiple properties.

### Solutions

We create two intermediate wrappers that will be used in type-erased boxes to access the property of an erased value. These wrappers generate the two getters and setters closures automatically using key paths.

- `AnyConstantProperty<Value>`: for constants
- `AnyMutableProperty<Value>`: for mutable properties in a class

Updating our previous example using those would look like this:

~~~swift
class AnyMessage {
    private let _likes: AnyMutableProperty<Int>

    init<T: Message>(_ message: T) {
        _likes = AnyMutableProperty(message, \.likes)
    }

    var likes: Int {
        get { return _likes.getter() }
        set { _likes.setter(newValue) }
    }
}
~~~
