### PR TITLE
Expose state of ZMTimer publicly

### DIFF
--- a/Source/Public/ZMTimer.h
+++ b/Source/Public/ZMTimer.h
@@ -28,12 +28,17 @@
 
 @end
 
-
+typedef NS_ENUM(NSUInteger, ZMTimerState) {
+    ZMTimerStateNotStarted,
+    ZMTimerStateStarted,
+    ZMTimerStateFinished
+};
 
 @interface ZMTimer : NSObject
 
 @property (nonatomic) NSDictionary *userInfo;
 
+@property (nonatomic, readonly) ZMTimerState state;
 @property (nonatomic, readonly, weak) id<ZMTimerClient> target;
 
 + (instancetype)timerWithTarget:(id<ZMTimerClient>)target;

--- a/Source/ZMTimer.m
+++ b/Source/ZMTimer.m
@@ -21,19 +21,12 @@
 #import "ZMTimer.h"
 
 
-typedef NS_ENUM(NSUInteger, ZMTimerState) {
-    ZMTimerStateNotStarted,
-    ZMTimerStateStarted,
-    ZMTimerStateFinished
-};
-
-
 @interface ZMTimer ()
 
 @property (nonatomic, weak) id<ZMTimerClient> target;
 @property (nonatomic) NSOperationQueue *queue;
 @property (nonatomic) dispatch_source_t timer;
-@property (nonatomic) ZMTimerState state;
+@property (nonatomic, readwrite) ZMTimerState state;
 
 @end
 
@@ -62,7 +55,7 @@ typedef NS_ENUM(NSUInteger, ZMTimerState) {
 
 - (void)dealloc
 {
-    RequireString(self.state == ZMTimerStateFinished, "ZMTimer was not cleaned up correctly");
+    RequireString(self.state == ZMTimerStateFinished || self.state == ZMTimerStateNotStarted, "ZMTimer was not cleaned up correctly");
 }
 
 + (instancetype)timerWithTarget:(id<ZMTimerClient>)target;


### PR DESCRIPTION
## What's new in this PR?

### Issues

Clients of the timer were not able to access its state. While this fits most scenarios, we need to be able to access the state of the timer when it is used inside expiring background tasks.

Typically, when the background task that accesses the timer expires, we need to act like the timer fired, and cancel it if it is running. For example, we might need to do something like this:

~~~swift
class BackgroundRequestTimer {
    let timer = ZMTimer(target: self)

    func start() {
        let activity = BackgroundActivityFactory.shared.beginBackgroundActivity()
        activity?.expirationHandler = self.finish

        if activity != nil {
            self.timer.start()
        } else {
            finish()
        }
    }

    func timerFired(_ timer: ZMTimer) {
        self.finish()
    }

    func finish() {
        if timer.state == .running {
            timer.cancel()
        }

        Network.cancelRequests()
    }
}
~~~

In this scenario, `finish` could have been called twice if we didn't check the state of the timer to cancel if the task expires before the timer fires (called from the `expirationHandler` and the `timerFired`) - which means `Network.cancelRequests` would also have been called twice, which can be a problem.

### Solutions

Expose the state enum publicly, and make the state property readonly in public contexts.

### Note

This PR also fixes a small bug where the app would crash if the timer was deallocated if it was never started, which occurred when the background task expired before we could start the timer.

This also improves testing opportunities, as we can now check the state of the timer.