### PR TITLE
Feature/ipc

### DIFF
--- a/Source/DarwinNotificationCenter.swift
+++ b/Source/DarwinNotificationCenter.swift
@@ -32,7 +32,10 @@ public class DarwinNotificationCenter {
     
     /// Invokes the given handler when the given notification is fired.
     public func observe(notification: DarwinNotification, using handler: @escaping Handler) {
-        handlers[notification, default: []].append(handler)
+        defer { handlers[notification, default: []].append(handler) }
+        
+        // we only want to internally observe each notification once
+        guard handlers[notification] == nil else { return }
         
         notification.observe { (_, _, name, _, _) in
             guard let name = name else { return }

--- a/Source/DarwinNotificationCenter.swift
+++ b/Source/DarwinNotificationCenter.swift
@@ -1,0 +1,89 @@
+//
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+/// A wrapper class to simplify observation of Darwin Notifications.
+///
+public class DarwinNotificationCenter {
+    
+    public static var shared = DarwinNotificationCenter()
+    
+    public typealias Handler = () -> Void
+    
+    private var handlers = [DarwinNotification : [Handler]]()
+    
+    private init() {}
+    
+    /// Invokes the given handler when the given notification is fired.
+    public func observe(notification: DarwinNotification, using handler: @escaping Handler) {
+        handlers[notification, default: []].append(handler)
+        
+        notification.observe { (_, _, name, _, _) in
+            guard let name = name else { return }
+            DarwinNotificationCenter.shared.forward(notification: name.rawValue as String)
+        }
+    }
+    
+    /// `CFNotificationCallback`s can't capture the environment, so instead we
+    /// forward the fired notification name and then invoke the relevant handlers.
+    func forward(notification name: String) {
+        guard let notification = DarwinNotification(rawValue: name) else { return }
+        handlers[notification]?.forEach { $0() }
+    }
+}
+
+/// Darwin Notifications are used to communicate between an extension and the
+/// containing app. Note, this "communication" is extremely limited; it is
+/// simply a ping that a particular event occurred. Add a case to this enum
+/// for each event you wish to post/observe.
+///
+public enum DarwinNotification: String {
+    case shareExtDidSaveNote = "darwin-notification.share-ext-did-save-note"
+    
+    var name: CFNotificationName {
+        return CFNotificationName(rawValue: self.rawValue as CFString)
+    }
+    
+    func observe(using block: @escaping CFNotificationCallback) {
+        // The use of Darwin Notification Center means some arguments will
+        // be ignored.
+        let nc = CFNotificationCenterGetDarwinNotifyCenter()
+        CFNotificationCenterAddObserver(
+            nc,                                 // notification center
+            nil,                                // observer
+            block,                              // callback
+            name.rawValue,                      // notification name
+            nil,                                // object (ignored)
+            .deliverImmediately                 // suspension behaviour (ignored)
+        )
+    }
+    
+    public func post() {
+        // The use of Darwin Notification Center means some arguments will
+        // be ignored.
+        let nc = CFNotificationCenterGetDarwinNotifyCenter()
+        CFNotificationCenterPostNotification(
+            nc,                                 // notification center
+            name,                               // notification name
+            nil,                                // object (ignored)
+            nil,                                // user info (ignored)
+            true                                // deliver immediately (ignored)
+        )
+    }
+}

--- a/Tests/DarwinNotificationCenterTests.swift
+++ b/Tests/DarwinNotificationCenterTests.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2018 Wire Swiss GmbH
+// Copyright (C) 2019 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/Tests/DarwinNotificationCenterTests.swift
+++ b/Tests/DarwinNotificationCenterTests.swift
@@ -1,0 +1,39 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+import WireUtilities
+
+class DarwinNotificationCenterTests: XCTestCase {
+    
+    func testThatItInvokesHandlers() {
+        // given
+        let sut = DarwinNotificationCenter.shared
+        let firstHandler = expectation(description: "first handler called")
+        let secondHandler = expectation(description: "second handler called")
+        
+        sut.observe(notification: .shareExtDidSaveNote) { firstHandler.fulfill() }
+        sut.observe(notification: .shareExtDidSaveNote) { secondHandler.fulfill() }
+        
+        // when
+        DarwinNotification.shareExtDidSaveNote.post()
+        
+        // then
+        wait(for: [firstHandler, secondHandler], timeout: 0.5)
+    }
+}

--- a/WireUtilities.xcodeproj/project.pbxproj
+++ b/WireUtilities.xcodeproj/project.pbxproj
@@ -133,6 +133,7 @@
 		D56A2D4A207E408C00DB59F5 /* NSManagedObjectContext+SwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D56A2D49207E408C00DB59F5 /* NSManagedObjectContext+SwiftTests.swift */; };
 		D5D65A13207631A100D7F3C3 /* NSManagedObjectContext+PerformGrouped.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D65A12207631A100D7F3C3 /* NSManagedObjectContext+PerformGrouped.swift */; };
 		EE1E354221E7739400F1144B /* DarwinNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1E354121E7739400F1144B /* DarwinNotificationCenter.swift */; };
+		EE1E357421E796F100F1144B /* DarwinNotificationCenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1E357321E796F100F1144B /* DarwinNotificationCenterTests.swift */; };
 		EECE48C71FFBE45D0015BAE8 /* FixedWidthInteger_RandomTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECE48C61FFBE45D0015BAE8 /* FixedWidthInteger_RandomTests.swift */; };
 		EECE92301FFBC5540096387F /* FixedWidthInteger+Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECE922F1FFBC5540096387F /* FixedWidthInteger+Random.swift */; };
 		EF18C7D21F9E37CA0085A832 /* String+Filename.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF18C7D11F9E37CA0085A832 /* String+Filename.swift */; };
@@ -365,6 +366,7 @@
 		D56A2D49207E408C00DB59F5 /* NSManagedObjectContext+SwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+SwiftTests.swift"; sourceTree = "<group>"; };
 		D5D65A12207631A100D7F3C3 /* NSManagedObjectContext+PerformGrouped.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+PerformGrouped.swift"; sourceTree = "<group>"; };
 		EE1E354121E7739400F1144B /* DarwinNotificationCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DarwinNotificationCenter.swift; sourceTree = "<group>"; };
+		EE1E357321E796F100F1144B /* DarwinNotificationCenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DarwinNotificationCenterTests.swift; sourceTree = "<group>"; };
 		EECE48C61FFBE45D0015BAE8 /* FixedWidthInteger_RandomTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedWidthInteger_RandomTests.swift; sourceTree = "<group>"; };
 		EECE922F1FFBC5540096387F /* FixedWidthInteger+Random.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FixedWidthInteger+Random.swift"; sourceTree = "<group>"; };
 		EF18C7D11F9E37CA0085A832 /* String+Filename.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Filename.swift"; sourceTree = "<group>"; };
@@ -755,6 +757,7 @@
 				5E7C6CBF214AA197004C30B5 /* AtomicIntegerTests.swift */,
 				5E4BC1BD2189EA3900A8682E /* AnyPropertyTests.swift */,
 				16030DC121AEA14100F8032E /* ArrayPartitionByKeyPathTests.swift */,
+				EE1E357321E796F100F1144B /* DarwinNotificationCenterTests.swift */,
 			);
 			name = Source;
 			sourceTree = "<group>";
@@ -1065,6 +1068,7 @@
 				EECE48C71FFBE45D0015BAE8 /* FixedWidthInteger_RandomTests.swift in Sources */,
 				546E8A591B750384009EBA02 /* NSManagedObjectContext+WireUtilitiesTests.m in Sources */,
 				BF3C1B1020DA7339001CE126 /* Equatable+OneOfTests.swift in Sources */,
+				EE1E357421E796F100F1144B /* DarwinNotificationCenterTests.swift in Sources */,
 				D504CD3B2090D00500A78DAA /* FlipTests.swift in Sources */,
 				546E8A4C1B74FF8F009EBA02 /* NSData+ZMAdditionsTests.m in Sources */,
 				872633E81D929C28008B69D8 /* OptionalComparisonTests.swift in Sources */,

--- a/WireUtilities.xcodeproj/project.pbxproj
+++ b/WireUtilities.xcodeproj/project.pbxproj
@@ -132,6 +132,7 @@
 		D53DB9A2203ED6E100655CB4 /* ResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53DB9A0203ED6DC00655CB4 /* ResultTests.swift */; };
 		D56A2D4A207E408C00DB59F5 /* NSManagedObjectContext+SwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D56A2D49207E408C00DB59F5 /* NSManagedObjectContext+SwiftTests.swift */; };
 		D5D65A13207631A100D7F3C3 /* NSManagedObjectContext+PerformGrouped.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D65A12207631A100D7F3C3 /* NSManagedObjectContext+PerformGrouped.swift */; };
+		EE1E354221E7739400F1144B /* DarwinNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1E354121E7739400F1144B /* DarwinNotificationCenter.swift */; };
 		EECE48C71FFBE45D0015BAE8 /* FixedWidthInteger_RandomTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECE48C61FFBE45D0015BAE8 /* FixedWidthInteger_RandomTests.swift */; };
 		EECE92301FFBC5540096387F /* FixedWidthInteger+Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECE922F1FFBC5540096387F /* FixedWidthInteger+Random.swift */; };
 		EF18C7D21F9E37CA0085A832 /* String+Filename.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF18C7D11F9E37CA0085A832 /* String+Filename.swift */; };
@@ -363,6 +364,7 @@
 		D53DB9A0203ED6DC00655CB4 /* ResultTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultTests.swift; sourceTree = "<group>"; };
 		D56A2D49207E408C00DB59F5 /* NSManagedObjectContext+SwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+SwiftTests.swift"; sourceTree = "<group>"; };
 		D5D65A12207631A100D7F3C3 /* NSManagedObjectContext+PerformGrouped.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+PerformGrouped.swift"; sourceTree = "<group>"; };
+		EE1E354121E7739400F1144B /* DarwinNotificationCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DarwinNotificationCenter.swift; sourceTree = "<group>"; };
 		EECE48C61FFBE45D0015BAE8 /* FixedWidthInteger_RandomTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedWidthInteger_RandomTests.swift; sourceTree = "<group>"; };
 		EECE922F1FFBC5540096387F /* FixedWidthInteger+Random.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FixedWidthInteger+Random.swift"; sourceTree = "<group>"; };
 		EF18C7D11F9E37CA0085A832 /* String+Filename.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Filename.swift"; sourceTree = "<group>"; };
@@ -552,6 +554,7 @@
 				5EE020C5214A9FC5001669F0 /* ZMAtomicInteger.m */,
 				5E4BC1BB2189E6A400A8682E /* AnyProperty.swift */,
 				16030DBF21AEA0FE00F8032E /* Array+PartitionByKeyPath.swift */,
+				EE1E354121E7739400F1144B /* DarwinNotificationCenter.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -1036,6 +1039,7 @@
 				D53DB99F203ED59C00655CB4 /* Result.swift in Sources */,
 				8735AE6F2035E3BC00DCE66E /* StringLengthValidator.swift in Sources */,
 				F9479C751E4A2D0F0039F55F /* NSOrderedSet.swift in Sources */,
+				EE1E354221E7739400F1144B /* DarwinNotificationCenter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## What's new in this PR?

This Darwin Notification implementation has been moved here from `WireShareEngine` since `WireUtilities`  is a more suitable framework. Some minor adjustments have been made too:

`DarwinNotificationCenter` is a simple class intended to simplify the observation of `DarwinNotification`s. It is a singleton object used to register potentially many callback handlers for each notification type (currently there is just one: `shareExtDidSaveNote`). 

The reason for this class is to abstract away the low level C API offered by `CFNotificationCenter`. As such, a user can simply observe a `DarwinNotification` with a standard Swift callback, avoiding the restrictions of a `CFNotificationCallback` which doesn't allow environment capturing.

The `DarwinNotificationCenter` acts as a middle man between the user and the `CFNotificationCenter` framework: users register as many callbacks to a certain notification as they like, meanwhile `DarwinNotificationCenter` will register it's own internal callback via `CFNotificationCenter` just once. Each time this internal callback is invoked, it invokes all user facing Swift callbacks tied to that notification.