### PR TITLE
ZIOS-11350: Implement password validation rules

### DIFF
--- a/Source/Password/PasswordCharacterClass.swift
+++ b/Source/Password/PasswordCharacterClass.swift
@@ -1,0 +1,123 @@
+//
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+/**
+ * The characters that can be used in a password safety rule.
+ */
+
+public enum PasswordCharacterClass: Hashable, Decodable {
+
+    /// All unicode characters.
+    case unicode
+
+    /// All uppercase characters.
+    case uppercase
+
+    /// All lowercase characters.
+    case lowercase
+
+    /// All the digits between 0 and 9.
+    case digits
+
+    /// Special characters.
+    case special
+
+    /// All ASCII printable characters.
+    case asciiPrintable
+
+    /// A user-defined character set.
+    case custom(String)
+
+    // MARK: - Raw Representation
+
+    /**
+     * Creates the character class from its raw representation.
+     * - parameter rawValue: The string describing the character class.
+     */
+
+    init?(rawValue: String) {
+        switch rawValue {
+        case "unicode": self = .unicode
+        case "upper": self = .uppercase
+        case "lower": self = .lowercase
+        case "digits": self = .digits
+        case "special": self = .special
+        case "ascii-printable": self = .asciiPrintable
+        default:
+            // Custom sets are wrapped between square brackets
+            guard rawValue.hasPrefix("[") && rawValue.hasSuffix("]") else { return nil }
+
+            // Get the contents between the brackets
+            let setStartIndex = rawValue.index(after: rawValue.startIndex)
+            let setEndIndex = rawValue.index(before: rawValue.endIndex)
+
+            // Create the character set
+            let setContents = rawValue[setStartIndex ..< setEndIndex]
+            self = .custom(String(setContents))
+        }
+    }
+
+    /// The string describing the character set.
+    var rawValue: String {
+        switch self {
+        case .unicode: return "unicode"
+        case .uppercase: return "upper"
+        case .lowercase: return "lower"
+        case .digits: return "digits"
+        case .special: return "special"
+        case .asciiPrintable: return "ascii-printable"
+        case .custom(let characterSet): return "[\(characterSet)]"
+        }
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(String.self)
+
+        guard let decodedSet = PasswordCharacterClass(rawValue: rawValue) else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "'\(rawValue)' is not a valid character set.")
+        }
+
+        self = decodedSet
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+
+    // MARK: - Standard Character Set
+
+    /// The standard character set that represents the character class.
+    var associatedCharacterSet: CharacterSet {
+        switch self {
+        case .unicode: return .alphanumerics
+        case .uppercase: return .uppercaseLetters
+        case .lowercase: return .lowercaseLetters
+        case .digits: return .decimalDigits
+        case .special: return CharacterSet(charactersIn: "-~!@#$%^&*_+=`|(){}[:;\"'<>,.? ]\u{0020}")
+        case .asciiPrintable: return .asciiPrintableSet
+        case .custom(let charactersString): return CharacterSet(charactersIn: charactersString)
+        }
+    }
+
+}

--- a/Source/Password/PasswordRuleSet.swift
+++ b/Source/Password/PasswordRuleSet.swift
@@ -1,0 +1,147 @@
+//
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+/**
+ * A set of password rules that can be used to check if a password is valid.
+ */
+
+public struct PasswordRuleSet: Decodable {
+
+    /// The minimum length of the password.
+    public let minimumLength: UInt
+
+    /// The maximum length of the password.
+    public let maximumLength: UInt
+
+    /// The allowed set of characters.
+    public let allowedCharacters: Set<PasswordCharacterClass>
+
+    /// The character set that represents the union of all the characters in `allowedCharacters`.
+    public let allowedCharacterSet: CharacterSet
+
+    /// The required set of characters.
+    public let requiredCharacterSets: [PasswordCharacterClass: CharacterSet]
+
+    // MARK: - Initialization
+
+    /**
+     * Creates the rule set from its required values.
+     * - parameter minimumLength: The minimum length of the password.
+     * - parameter maximumLength: The maximum length of the password.
+     * - parameter allowedCharacters: The characters that are allowed in the password.
+     * - parameter requiredCharacters: The characters that are required in the password. Note that if these are
+     * not included in `allowedCharacters`, they will be added to that set.
+     */
+
+    public init(minimumLength: UInt, maximumLength: UInt, allowedCharacters: Set<PasswordCharacterClass>, requiredCharacters: Set<PasswordCharacterClass>) {
+        self.minimumLength = minimumLength
+        self.maximumLength = maximumLength
+
+        // Parse the allowed and required characters
+        var allowedCharacters = allowedCharacters
+        var allowedCharacterSet = allowedCharacters.reduce(into: CharacterSet()) { $0.formUnion($1.associatedCharacterSet) }
+        var requiredCharacterSets: [PasswordCharacterClass: CharacterSet] = [:]
+
+        for requiredClass in requiredCharacters {
+            allowedCharacters.insert(requiredClass)
+            let characterSet = requiredClass.associatedCharacterSet
+            allowedCharacterSet.formUnion(characterSet)
+            requiredCharacterSets[requiredClass] = characterSet
+        }
+
+        self.allowedCharacters = allowedCharacters
+        self.allowedCharacterSet = allowedCharacterSet
+        self.requiredCharacterSets = requiredCharacterSets
+    }
+
+    // MARK: - Codable
+
+    private enum CodingKeys: String, CodingKey {
+        case minimumLength = "minimumLength"
+        case maximumLength = "maximumLength"
+        case allowedCharacters = "allowedCharacters"
+        case requiredCharacters = "requiredCharacters"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let minimumLength = try container.decode(UInt.self, forKey: .allowedCharacters)
+        let maximumLength = try container.decode(UInt.self, forKey: .requiredCharacters)
+        let allowedCharacters = try container.decode(Set<PasswordCharacterClass>.self, forKey: .allowedCharacters)
+        let requiredCharacters = try container.decode(Set<PasswordCharacterClass>.self, forKey: .requiredCharacters)
+        self.init(minimumLength: minimumLength, maximumLength: maximumLength, allowedCharacters: allowedCharacters, requiredCharacters: requiredCharacters)
+    }
+
+    // MARK: - Encoding
+
+    /// Encodes the rules in the format used by the Apple keychain.
+    public func encodeInKeychainFormat() -> String {
+        let allowed = allowedCharacters.reduce(into: "") { $0 += "allowed: \($1.rawValue);" }
+        let required = requiredCharacterSets.keys.reduce(into: "") { $0 += "required: \($1.rawValue);" }
+        return "minlength: \(minimumLength); maxlength: \(maximumLength); \(allowed) \(required)"
+    }
+
+    // MARK: - Validation
+
+    /**
+     * Verifies that the specified password conforms to this password rule set.
+     * - parameter password: The password to validate.
+     * - returns: The validation result. `valid` if the password is valid, or
+     * the description of the error.
+     */
+
+    public func validatePassword(_ password: String) -> PasswordValidationResult {
+        let length = password.count
+
+        // Start by checking the length.
+        if length < minimumLength {
+            return .tooShort
+        }
+
+        if length > maximumLength {
+            return .tooLong
+        }
+
+        // Check for allowed and requiredCharacters
+        var matchedRequiredClasses: Set<PasswordCharacterClass> = []
+        let requiredClasses = Set(requiredCharacterSets.keys)
+
+        for scalar in password.unicodeScalars {
+            guard allowedCharacterSet.contains(scalar) else {
+                return .disallowedCharacter(scalar)
+            }
+
+            for (requiredClass, requiredCharacters) in requiredCharacterSets where !matchedRequiredClasses.contains(requiredClass) {
+                if requiredCharacters.contains(scalar) {
+                    matchedRequiredClasses.insert(requiredClass)
+                }
+            }
+
+            // Check early if all the character classes are matched.
+            if requiredClasses.all(matchedRequiredClasses.contains) {
+                return .valid
+            }
+        }
+
+        // If all the required character classes are not matched, we return an error.
+        return .missingRequiredCharacters(requiredClasses.subtracting(matchedRequiredClasses))
+    }
+
+}

--- a/Source/Password/PasswordValidationResult.swift
+++ b/Source/Password/PasswordValidationResult.swift
@@ -37,6 +37,6 @@ public enum PasswordValidationResult: Equatable {
     case disallowedCharacter(Unicode.Scalar)
 
     /// The password does not satisfy a requirement for a character class.
-    case missingRequiredCharacters(Set<PasswordCharacterClass>)
+    case missingRequiredClasses(Set<PasswordCharacterClass>)
 
 }

--- a/Source/Password/PasswordValidationResult.swift
+++ b/Source/Password/PasswordValidationResult.swift
@@ -1,0 +1,42 @@
+//
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+/**
+ * The result of password validation.
+ */
+
+public enum PasswordValidationResult: Equatable {
+
+    /// The password is valid.
+    case valid
+
+    /// The password is too short.
+    case tooShort
+
+    /// The password is too long.
+    case tooLong
+
+    /// The password contains a disallowed character.
+    case disallowedCharacter(Unicode.Scalar)
+
+    /// The password does not satisfy a requirement for a character class.
+    case missingRequiredCharacters(Set<PasswordCharacterClass>)
+
+}

--- a/Source/Public/String+Emoji.swift
+++ b/Source/Public/String+Emoji.swift
@@ -17,7 +17,7 @@
 //
 
 extension CharacterSet {
-    static let asciiPrintableSet = CharacterSet(charactersIn: "!\"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~")
+    static let asciiPrintableSet = CharacterSet(charactersIn: "\u{0020}!\"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~")
 }
 
 extension Unicode.Scalar {

--- a/Tests/PasswordRuleSetTests.swift
+++ b/Tests/PasswordRuleSetTests.swift
@@ -1,0 +1,135 @@
+//
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+@testable import WireUtilities
+
+class PasswordRuleSetTests: XCTestCase {
+
+    // MARK: - Creation
+
+    func testThatItAddsRequiredCharactersToAllowedSet() {
+        // GIVEN
+        let ruleSet = PasswordRuleSet(minimumLength: 10, maximumLength: 100, allowedCharacters: [.asciiPrintable], requiredCharacters: [.custom("🐼")])
+
+        // THEN
+        let panda = Unicode.Scalar(Int(0x1F43C))!
+        let pandaCharset = CharacterSet(charactersIn: "🐼")
+
+        XCTAssertEqual(ruleSet.requiredCharacterSets, [.custom("🐼"): pandaCharset])
+        XCTAssertTrue(ruleSet.allowedCharacterSet.contains(panda))
+        XCTAssertTrue(ruleSet.allowedCharacterSet.isSuperset(of: CharacterSet.asciiPrintableSet))
+    }
+
+    // MARK: - Validation
+
+    func testThatItDetectsTooShortPassword() {
+        // GIVEN
+        let ruleSet = PasswordRuleSet(minimumLength: 10, maximumLength: 100, allowedCharacters: [.unicode], requiredCharacters: [.digits])
+        let shortPassword = "123456789"
+
+        // WHEN
+        let result = ruleSet.validatePassword(shortPassword)
+
+        // THEN
+        XCTAssertEqual(result, .tooShort)
+    }
+
+    func testThatItDetectsTooLongPassword() {
+        // GIVEN
+        let ruleSet = PasswordRuleSet(minimumLength: 2, maximumLength: 8, allowedCharacters: [.unicode], requiredCharacters: [.digits])
+        let longPassword = "123456789"
+
+        // WHEN
+        let result = ruleSet.validatePassword(longPassword)
+
+        // THEN
+        XCTAssertEqual(result, .tooLong)
+    }
+
+    func testThatItDetectsDisallowedCharacter() {
+        // GIVEN
+        let ruleSet = PasswordRuleSet(minimumLength: 8, maximumLength: 120, allowedCharacters: [.asciiPrintable], requiredCharacters: [.digits])
+        let passwordWithHebrew = "1Passworד"
+
+        // WHEN
+        let result = ruleSet.validatePassword(passwordWithHebrew)
+
+        // THEN
+        let dalet = Unicode.Scalar(Int(0x05D3))!
+        XCTAssertEqual(result, .disallowedCharacter(dalet))
+    }
+
+    func testThatItDetectsMissingClasses() {
+        // GIVEN
+        let ruleSet = PasswordRuleSet(minimumLength: 8, maximumLength: 120, allowedCharacters: [.asciiPrintable], requiredCharacters: [.digits, .special, .uppercase, .lowercase])
+        let plainPassword = "Wire2019"
+
+        // WHEN
+        let result = ruleSet.validatePassword(plainPassword)
+
+        // THEN
+        XCTAssertEqual(result, .missingRequiredClasses([.special]))
+    }
+
+    // MARK: - Codable
+
+    func testThatItDecodesFromJSON() throws {
+        // GIVEN
+        let json = """
+        {
+            "minimum-length": 8,
+            "maximum-length": 120,
+            "allowed-characters": [
+                "ascii-printable",
+            ],
+            "required-characters": [
+                "digits",
+                "[🐼]"
+            ]
+        }
+        """
+
+        // WHEN
+        let jsonDecoder = JSONDecoder()
+        let ruleSet = try jsonDecoder.decode(PasswordRuleSet.self, from: Data(json.utf8))
+
+        // THEN
+        let panda = Unicode.Scalar(Int(0x1F43C))!
+        let pandaCharset = CharacterSet(charactersIn: "🐼")
+
+        XCTAssertEqual(ruleSet.minimumLength, 8)
+        XCTAssertEqual(ruleSet.maximumLength, 120)
+        XCTAssertEqual(ruleSet.allowedCharacters, [.asciiPrintable, .digits, .custom("🐼")])
+        XCTAssertTrue(ruleSet.allowedCharacterSet.contains(panda))
+        XCTAssertTrue(ruleSet.allowedCharacterSet.isSuperset(of: CharacterSet.asciiPrintableSet))
+        XCTAssertEqual(ruleSet.requiredCharacterSets, [.digits: .decimalDigits, .custom("🐼"): pandaCharset])
+    }
+
+    func testThatItEncodesToAppleKeychainFormat() {
+        // GIVEN
+        let ruleSet = PasswordRuleSet(minimumLength: 10, maximumLength: 100, allowedCharacters: [.asciiPrintable], requiredCharacters: [.custom("🐼")])
+
+        // WHEN
+        let keychainFormat = ruleSet.encodeInKeychainFormat()
+
+        // THEN
+        XCTAssertEqual(keychainFormat, "minlength: 10; maxlength: 100; allowed: ascii-printable; allowed: [🐼]; required: [🐼];")
+    }
+
+}

--- a/Tests/Source/UnownedNSObjectTests.swift
+++ b/Tests/Source/UnownedNSObjectTests.swift
@@ -22,9 +22,7 @@ import WireUtilities
 
 class UnownedNSObjectTests: XCTestCase {
 
-    
     func testThatCreatingAnUnownedNSObjectWithALocallyScopedObjectIsValid() {
-        
         let unown = UnownedNSObject(NSNumber(value: 10))
         XCTAssertTrue(unown.isValid)
         XCTAssertEqual(NSNumber(value: 10), unown.unbox!)
@@ -32,11 +30,11 @@ class UnownedNSObjectTests: XCTestCase {
     
     
     func testThatUnownedNSObjectIsInvalidIfValueDoesNotExistAnymore() {
-        
         var array : Array<Date>? = [Date()]
         let unownedObject = UnownedNSObject(array![0] as NSObject)
         array = nil
         XCTAssertFalse(unownedObject.isValid)
         XCTAssertNil(unownedObject.unbox)
     }
+
 }

--- a/WireUtilities.xcodeproj/project.pbxproj
+++ b/WireUtilities.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		5E39FC52225B350700C682B8 /* PasswordRuleSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E39FC51225B350700C682B8 /* PasswordRuleSet.swift */; };
 		5E39FC55225B399D00C682B8 /* PasswordCharacterClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E39FC54225B399D00C682B8 /* PasswordCharacterClass.swift */; };
 		5E39FC59225B55F200C682B8 /* PasswordValidationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E39FC58225B55F200C682B8 /* PasswordValidationResult.swift */; };
+		5E39FC5B225B747600C682B8 /* PasswordRuleSetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E39FC5A225B747600C682B8 /* PasswordRuleSetTests.swift */; };
 		5E4BC1BC2189E6A400A8682E /* AnyProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E4BC1BB2189E6A400A8682E /* AnyProperty.swift */; };
 		5E4BC1BE2189EA3900A8682E /* AnyPropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E4BC1BD2189EA3900A8682E /* AnyPropertyTests.swift */; };
 		5E4BC1C6218C830500A8682E /* String+Spaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E4BC1C5218C830500A8682E /* String+Spaces.swift */; };
@@ -332,6 +333,7 @@
 		5E39FC51225B350700C682B8 /* PasswordRuleSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordRuleSet.swift; sourceTree = "<group>"; };
 		5E39FC54225B399D00C682B8 /* PasswordCharacterClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordCharacterClass.swift; sourceTree = "<group>"; };
 		5E39FC58225B55F200C682B8 /* PasswordValidationResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordValidationResult.swift; sourceTree = "<group>"; };
+		5E39FC5A225B747600C682B8 /* PasswordRuleSetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordRuleSetTests.swift; sourceTree = "<group>"; };
 		5E4BC1BB2189E6A400A8682E /* AnyProperty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyProperty.swift; sourceTree = "<group>"; };
 		5E4BC1BD2189EA3900A8682E /* AnyPropertyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyPropertyTests.swift; sourceTree = "<group>"; };
 		5E4BC1C5218C830500A8682E /* String+Spaces.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Spaces.swift"; sourceTree = "<group>"; };
@@ -787,6 +789,7 @@
 				EE1E357321E796F100F1144B /* DarwinNotificationCenterTests.swift */,
 				16B75F67222EE3A000DCAFF2 /* String+StrippingTests.swift */,
 				5E9EA4C222423EA600D401B2 /* ArraySafeIndexTests.swift */,
+				5E39FC5A225B747600C682B8 /* PasswordRuleSetTests.swift */,
 			);
 			name = Source;
 			sourceTree = "<group>";
@@ -1115,6 +1118,7 @@
 				16030DC221AEA14100F8032E /* ArrayPartitionByKeyPathTests.swift in Sources */,
 				F9C9A78E1CAEA0110039E10C /* NSString_NormalizationTests.m in Sources */,
 				BFBAE9DD1E01A930003FCE49 /* String+EmojiTests.swift in Sources */,
+				5E39FC5B225B747600C682B8 /* PasswordRuleSetTests.swift in Sources */,
 				871E12351C4FEED200862958 /* UnownedNSObjectTests.swift in Sources */,
 				F9D381B01B70B94300E6E4EB /* ZMFunctionalTests.m in Sources */,
 				BFA2F03920C9490500EBE97C /* FunctionOperatorTests.swift in Sources */,

--- a/WireUtilities.xcodeproj/project.pbxproj
+++ b/WireUtilities.xcodeproj/project.pbxproj
@@ -87,6 +87,9 @@
 		54FA8E821BC6CC3400E42980 /* NSData+ZMSCryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54FA8E811BC6CC3400E42980 /* NSData+ZMSCryptoTests.swift */; };
 		5E0A1FF92105DBBA00949B3E /* Map+KeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0A1FF82105DBBA00949B3E /* Map+KeyPath.swift */; };
 		5E0A1FFC2105DE2700949B3E /* MapKeyPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0A1FFA2105DE2100949B3E /* MapKeyPathTests.swift */; };
+		5E39FC52225B350700C682B8 /* PasswordRuleSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E39FC51225B350700C682B8 /* PasswordRuleSet.swift */; };
+		5E39FC55225B399D00C682B8 /* PasswordCharacterClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E39FC54225B399D00C682B8 /* PasswordCharacterClass.swift */; };
+		5E39FC59225B55F200C682B8 /* PasswordValidationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E39FC58225B55F200C682B8 /* PasswordValidationResult.swift */; };
 		5E4BC1BC2189E6A400A8682E /* AnyProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E4BC1BB2189E6A400A8682E /* AnyProperty.swift */; };
 		5E4BC1BE2189EA3900A8682E /* AnyPropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E4BC1BD2189EA3900A8682E /* AnyPropertyTests.swift */; };
 		5E4BC1C6218C830500A8682E /* String+Spaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E4BC1C5218C830500A8682E /* String+Spaces.swift */; };
@@ -326,6 +329,9 @@
 		54FA8E811BC6CC3400E42980 /* NSData+ZMSCryptoTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "NSData+ZMSCryptoTests.swift"; path = "Source/NSData+ZMSCryptoTests.swift"; sourceTree = "<group>"; };
 		5E0A1FF82105DBBA00949B3E /* Map+KeyPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Map+KeyPath.swift"; sourceTree = "<group>"; };
 		5E0A1FFA2105DE2100949B3E /* MapKeyPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapKeyPathTests.swift; sourceTree = "<group>"; };
+		5E39FC51225B350700C682B8 /* PasswordRuleSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordRuleSet.swift; sourceTree = "<group>"; };
+		5E39FC54225B399D00C682B8 /* PasswordCharacterClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordCharacterClass.swift; sourceTree = "<group>"; };
+		5E39FC58225B55F200C682B8 /* PasswordValidationResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordValidationResult.swift; sourceTree = "<group>"; };
 		5E4BC1BB2189E6A400A8682E /* AnyProperty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyProperty.swift; sourceTree = "<group>"; };
 		5E4BC1BD2189EA3900A8682E /* AnyPropertyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyPropertyTests.swift; sourceTree = "<group>"; };
 		5E4BC1C5218C830500A8682E /* String+Spaces.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Spaces.swift"; sourceTree = "<group>"; };
@@ -567,6 +573,7 @@
 				EE1E354121E7739400F1144B /* DarwinNotificationCenter.swift */,
 				16B75F65222EDC5000DCAFF2 /* String+Stripping.swift */,
 				5E9EA4C022423E0300D401B2 /* Array+SafeIndex.swift */,
+				5E39FC53225B37EC00C682B8 /* Password */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -689,6 +696,16 @@
 				5E0A1FF82105DBBA00949B3E /* Map+KeyPath.swift */,
 			);
 			path = Public;
+			sourceTree = "<group>";
+		};
+		5E39FC53225B37EC00C682B8 /* Password */ = {
+			isa = PBXGroup;
+			children = (
+				5E39FC54225B399D00C682B8 /* PasswordCharacterClass.swift */,
+				5E39FC51225B350700C682B8 /* PasswordRuleSet.swift */,
+				5E39FC58225B55F200C682B8 /* PasswordValidationResult.swift */,
+			);
+			path = Password;
 			sourceTree = "<group>";
 		};
 		F9C9A79F1CAEACB10039E10C /* Validation */ = {
@@ -1007,6 +1024,7 @@
 				F9C9A7AC1CAEACB10039E10C /* ZMEmailAddressValidator.m in Sources */,
 				3E88BE3D1B1F478200232589 /* ZMDebugHelpers.m in Sources */,
 				3E88BF451B1F66B100232589 /* NSUUID+Data.m in Sources */,
+				5E39FC59225B55F200C682B8 /* PasswordValidationResult.swift in Sources */,
 				5E4BC1BC2189E6A400A8682E /* AnyProperty.swift in Sources */,
 				54CA313B1B74F36B00B820C0 /* Sets.swift in Sources */,
 				D5D65A13207631A100D7F3C3 /* NSManagedObjectContext+PerformGrouped.swift in Sources */,
@@ -1020,6 +1038,7 @@
 				BFBAE9DB1E01A8F2003FCE49 /* String+Emoji.swift in Sources */,
 				F9C9A7941CAEA7200039E10C /* ZMEncodedNSUUIDWithTimestamp.m in Sources */,
 				3E88BE231B1F478200232589 /* NSURL+QueryComponents.m in Sources */,
+				5E39FC55225B399D00C682B8 /* PasswordCharacterClass.swift in Sources */,
 				3E88BE431B1F478200232589 /* ZMFunctional+noARC.m in Sources */,
 				BF9D0B091F1CF3F8005D4C31 /* Optional+Apply.swift in Sources */,
 				16A5FDF7215A746B00AEEBBD /* IndexSet+Helpers.swift in Sources */,
@@ -1049,6 +1068,7 @@
 				87B6489C2076078A002FC9E7 /* Composition.swift in Sources */,
 				F9C9A7AE1CAEACB10039E10C /* ZMPhoneNumberValidator.m in Sources */,
 				3E88BE1F1B1F478200232589 /* NSSet+Zeta.m in Sources */,
+				5E39FC52225B350700C682B8 /* PasswordRuleSet.swift in Sources */,
 				54181A561F594FD800155ABC /* FileManager+FileProtectionLock.swift in Sources */,
 				16D964DC1F79454000390417 /* SelfUnregisteringNotificationCenterToken.swift in Sources */,
 				16EB9B361CE0D5A000883FCF /* UTType.swift in Sources */,

--- a/WireUtilities.xcodeproj/project.pbxproj
+++ b/WireUtilities.xcodeproj/project.pbxproj
@@ -873,9 +873,9 @@
 			productReference = 3E88BD381B1F3EA300232589 /* WireUtilities.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		3E88BD421B1F3EA300232589 /* WireUtilities-tests */ = {
+		3E88BD421B1F3EA300232589 /* WireUtilities-Tests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 3E88BD4F1B1F3EA300232589 /* Build configuration list for PBXNativeTarget "WireUtilities-tests" */;
+			buildConfigurationList = 3E88BD4F1B1F3EA300232589 /* Build configuration list for PBXNativeTarget "WireUtilities-Tests" */;
 			buildPhases = (
 				3E88BD3F1B1F3EA300232589 /* Sources */,
 				3E88BD401B1F3EA300232589 /* Frameworks */,
@@ -888,7 +888,7 @@
 				540EF2841EFD14AA00C6C6B5 /* PBXTargetDependency */,
 				3E88BD461B1F3EA300232589 /* PBXTargetDependency */,
 			);
-			name = "WireUtilities-tests";
+			name = "WireUtilities-Tests";
 			productName = WireUtilitiesTests;
 			productReference = 3E88BD431B1F3EA300232589 /* WireUtilities-Tests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -937,7 +937,7 @@
 			projectRoot = "";
 			targets = (
 				3E88BD371B1F3EA300232589 /* WireUtilities */,
-				3E88BD421B1F3EA300232589 /* WireUtilities-tests */,
+				3E88BD421B1F3EA300232589 /* WireUtilities-Tests */,
 				09F028CD1B78BE2700BADDB6 /* WireUtilities-tests-host */,
 			);
 		};
@@ -1310,7 +1310,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		3E88BD4F1B1F3EA300232589 /* Build configuration list for PBXNativeTarget "WireUtilities-tests" */ = {
+		3E88BD4F1B1F3EA300232589 /* Build configuration list for PBXNativeTarget "WireUtilities-Tests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				3E88BD501B1F3EA300232589 /* Debug */,

--- a/WireUtilities.xcodeproj/xcshareddata/xcschemes/WireUtilities.xcscheme
+++ b/WireUtilities.xcodeproj/xcshareddata/xcschemes/WireUtilities.xcscheme
@@ -30,7 +30,7 @@
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "3E88BD421B1F3EA300232589"
                BuildableName = "WireUtilities-Tests.xctest"
-               BlueprintName = "WireUtilities-tests"
+               BlueprintName = "WireUtilities-Tests"
                ReferencedContainer = "container:WireUtilities.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -49,7 +49,7 @@
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "3E88BD421B1F3EA300232589"
                BuildableName = "WireUtilities-Tests.xctest"
-               BlueprintName = "WireUtilities-tests"
+               BlueprintName = "WireUtilities-Tests"
                ReferencedContainer = "container:WireUtilities.xcodeproj">
             </BuildableReference>
          </TestableReference>


### PR DESCRIPTION
## What's new in this PR?

### Issues

We want to introduce password validation rules that can:

1. Be customized
2. Validate the length of the password
3. Validate that the password does not contain disallowed characters
4. Validate that the password contains at least one of each specified character classes

### Solutions

We introduce a new `PasswordRuleSet` object. This object contains all the properties required to validate a password. It can be created from a JSON object to allow clients to customize it in the Configuration file.

This is an example JSON that represents password rules:

```json
{
    "minimum-length": 8,
    "maximum-length": 120,
    "allowed-characters": [
        "ascii-printable",
    ],
    "required-characters": [
        "digits",
        "[🐼]"
    ]
}
```

The first two parameters are `minimumLength` and `maximumLength`. They are unsigned integers that are used to validate the length of the string.

The two other parameters are `allowedCharacters` and `requiredCharacters`. They are both represented as a set of `PasswordCharacterClass` enum cases. This enum contains common characters classes and allows for the creation of custom classes. 

From these two parameters, we construct a Foundation `CharacterSet` that contains the union of the `allowedCharacters` and `requiredCharacters`. We also construct a dictionary where the `requiredCharacters` are mapped to their associated `CharacterSet`.

To validate the password, we:
- check its length against the min and max length
- iterate over all the visible characters to check if they are allowed, and record if they match a required class
- check that all the required classes are matched once the iteration is over

During the validation process, we return specialized errors, so that we can update the text of the error in the UI if this becomes part of the requirements (not decided at this point). The list of special characters is also not fixed yet.

Most of the constants and structures are derived from the [Apple Password AutoFill Rules document](https://developer.apple.com/documentation/security/password_autofill/customizing_password_autofill_rules) so that we can generate compatible strings from our rule set, if we decide to support this feature eventually.