### PR TITLE
ZIOS-11350: Update password rules for new spec

### DIFF
--- a/Source/Password/PasswordCharacterClass.swift
+++ b/Source/Password/PasswordCharacterClass.swift
@@ -110,12 +110,12 @@ public enum PasswordCharacterClass: Hashable, Decodable {
     /// The standard character set that represents the character class.
     var associatedCharacterSet: CharacterSet {
         switch self {
-        case .unicode: return .alphanumerics
-        case .uppercase: return .uppercaseLetters
-        case .lowercase: return .lowercaseLetters
+        case .unicode: return .unicode
+        case .uppercase: return .asciiUppercaseLetters
+        case .lowercase: return .asciiLowercaseLetters
         case .digits: return .decimalDigits
-        case .special: return CharacterSet(charactersIn: "-~!@#$%^&*_+=`|(){}[:;\"'<>,.? ]\u{0020}")
         case .asciiPrintable: return .asciiPrintableSet
+        case .special: return CharacterSet.asciiStandardCharacters.inverted
         case .custom(let charactersString): return CharacterSet(charactersIn: charactersString)
         }
     }

--- a/Source/Password/PasswordRuleSet.swift
+++ b/Source/Password/PasswordRuleSet.swift
@@ -74,10 +74,10 @@ public struct PasswordRuleSet: Decodable {
     // MARK: - Codable
 
     private enum CodingKeys: String, CodingKey {
-        case minimumLength = "minimum-length"
-        case maximumLength = "maximum-length"
-        case allowedCharacters = "allowed-characters"
-        case requiredCharacters = "required-characters"
+        case minimumLength = "new_password_minimum_length"
+        case maximumLength = "new_password_maximum_length"
+        case allowedCharacters = "new_password_allowed_characters"
+        case requiredCharacters = "new_password_required_characters"
     }
 
     public init(from decoder: Decoder) throws {

--- a/Source/Public/String+Emoji.swift
+++ b/Source/Public/String+Emoji.swift
@@ -18,6 +18,10 @@
 
 extension CharacterSet {
     static let asciiPrintableSet = CharacterSet(charactersIn: "\u{0020}!\"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~")
+    static let unicode = CharacterSet(charactersIn: Unicode.Scalar(Int(0x0000))! ..< Unicode.Scalar(Int(0x10FFFF))!)
+    static let asciiUppercaseLetters = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+    static let asciiLowercaseLetters = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyz")
+    static let asciiStandardCharacters = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
 }
 
 extension Unicode.Scalar {


### PR DESCRIPTION
## What's new in this PR?

We need to update the password rules the after some discussions related to the spec this morning:

- Update the Unicode character class to include all scalars
- Update the uppercase/lowercase character class to include only ASCII
- Update the special character class to include all non ASCII lowercase/uppercase/digits
- Update the JSON keys of the rule set structure

### Notes

This will require an update of the build configuration.