### PR TITLE
Added readable hash for strings

### DIFF
--- a/Source/Public/Data+ReadableHash.swift
+++ b/Source/Public/Data+ReadableHash.swift
@@ -18,10 +18,10 @@
 
 import Foundation
 
-extension String {
+extension Data {
     /// Produces a hash that is 8 characters long. It can be used to obfuscate sensitive data but still allow matching it e.g. in logs.
     public var readableHash: String {
-        guard let data = data(using: .utf8) else { return "n/a" }
-        return data.readableHash
+        let hash = zmSHA256Digest().zmHexEncodedString()
+        return String(hash.prefix(8))
     }
 }

--- a/Source/Public/String+ReadableHash.swift
+++ b/Source/Public/String+ReadableHash.swift
@@ -1,0 +1,27 @@
+////
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension String {
+    /// Produces a hash that is 8 characters long. It can be used to obfuscate sensitive data but still allow matching it e.g. in logs.
+    public var readableHash: String {
+        guard let hash = data(using: .utf8)?.zmSHA256Digest().zmHexEncodedString() else { return "n/a" }
+        return String(hash.prefix(8))
+    }
+}

--- a/Source/Public/UUID+Data.swift
+++ b/Source/Public/UUID+Data.swift
@@ -22,7 +22,7 @@ public extension UUID {
     
     /// return a Data representation of this UUID
     var uuidData: Data {
-        return withUnsafeBytes(of: uuid, Data.init(bytes:))
+        return withUnsafeBytes(of: uuid, Data.init(_:))
     }
     
     

--- a/WireUtilities.xcodeproj/project.pbxproj
+++ b/WireUtilities.xcodeproj/project.pbxproj
@@ -151,6 +151,7 @@
 		EFC0C7B021772E6200380C4B /* EmojiOnlyStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF638D7B2170EDF000344C8A /* EmojiOnlyStringTests.swift */; };
 		EFD003562179FABC008C20D3 /* StringLengthValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFD003552179FABC008C20D3 /* StringLengthValidatorTests.swift */; };
 		F15BDB1E20889773002F36E8 /* TearDownCapable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15BDB1D20889772002F36E8 /* TearDownCapable.swift */; };
+		F19E554D22AFDC8D005C792D /* String+ReadableHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = F19E554C22AFDC8D005C792D /* String+ReadableHash.swift */; };
 		F1D567B1207BA40C00CCDD77 /* WireUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E88BD381B1F3EA300232589 /* WireUtilities.framework */; };
 		F1D567B5207BA50700CCDD77 /* WireUtilities.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3E88BD381B1F3EA300232589 /* WireUtilities.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F9479C751E4A2D0F0039F55F /* NSOrderedSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9479C741E4A2D0F0039F55F /* NSOrderedSet.swift */; };
@@ -394,6 +395,7 @@
 		EF638D7B2170EDF000344C8A /* EmojiOnlyStringTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmojiOnlyStringTests.swift; sourceTree = "<group>"; };
 		EFD003552179FABC008C20D3 /* StringLengthValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringLengthValidatorTests.swift; sourceTree = "<group>"; };
 		F15BDB1D20889772002F36E8 /* TearDownCapable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TearDownCapable.swift; sourceTree = "<group>"; };
+		F19E554C22AFDC8D005C792D /* String+ReadableHash.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+ReadableHash.swift"; sourceTree = "<group>"; };
 		F1E148C0207BAECF00F81833 /* ios-test-host.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "ios-test-host.xcconfig"; sourceTree = "<group>"; };
 		F1E148C2207BAED000F81833 /* tests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = tests.xcconfig; sourceTree = "<group>"; };
 		F1E148C4207BAED000F81833 /* project-debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "project-debug.xcconfig"; sourceTree = "<group>"; };
@@ -691,6 +693,7 @@
 				BF3493F31EC362D400B0C314 /* Iterator+Containment.swift */,
 				BFBAE9DA1E01A8F2003FCE49 /* String+Emoji.swift */,
 				5E4BC1C5218C830500A8682E /* String+Spaces.swift */,
+				F19E554C22AFDC8D005C792D /* String+ReadableHash.swift */,
 				870FFA811D82B73B007E9806 /* Data+ZMSCrypto.swift */,
 				877F501C1E719B2B00894C90 /* String+ExtremeCombiningCharacters.swift */,
 				163FB9071F22302C00802AF4 /* DispatchGroupQueue.swift */,
@@ -1045,6 +1048,7 @@
 				097E36C31B7B62150039CC4C /* NSLocale+Internal.m in Sources */,
 				BF3A7A601D8AA9B30034FF40 /* OptionalComparison.swift in Sources */,
 				BFBAE9DB1E01A8F2003FCE49 /* String+Emoji.swift in Sources */,
+				F19E554D22AFDC8D005C792D /* String+ReadableHash.swift in Sources */,
 				F9C9A7941CAEA7200039E10C /* ZMEncodedNSUUIDWithTimestamp.m in Sources */,
 				3E88BE231B1F478200232589 /* NSURL+QueryComponents.m in Sources */,
 				5E39FC55225B399D00C682B8 /* PasswordCharacterClass.swift in Sources */,

--- a/WireUtilities.xcodeproj/project.pbxproj
+++ b/WireUtilities.xcodeproj/project.pbxproj
@@ -152,6 +152,7 @@
 		EFD003562179FABC008C20D3 /* StringLengthValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFD003552179FABC008C20D3 /* StringLengthValidatorTests.swift */; };
 		F15BDB1E20889773002F36E8 /* TearDownCapable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15BDB1D20889772002F36E8 /* TearDownCapable.swift */; };
 		F19E554D22AFDC8D005C792D /* String+ReadableHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = F19E554C22AFDC8D005C792D /* String+ReadableHash.swift */; };
+		F19E55A822B3AAF3005C792D /* Data+ReadableHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = F19E55A722B3AAF3005C792D /* Data+ReadableHash.swift */; };
 		F1D567B1207BA40C00CCDD77 /* WireUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E88BD381B1F3EA300232589 /* WireUtilities.framework */; };
 		F1D567B5207BA50700CCDD77 /* WireUtilities.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3E88BD381B1F3EA300232589 /* WireUtilities.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F9479C751E4A2D0F0039F55F /* NSOrderedSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9479C741E4A2D0F0039F55F /* NSOrderedSet.swift */; };
@@ -396,6 +397,7 @@
 		EFD003552179FABC008C20D3 /* StringLengthValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringLengthValidatorTests.swift; sourceTree = "<group>"; };
 		F15BDB1D20889772002F36E8 /* TearDownCapable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TearDownCapable.swift; sourceTree = "<group>"; };
 		F19E554C22AFDC8D005C792D /* String+ReadableHash.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+ReadableHash.swift"; sourceTree = "<group>"; };
+		F19E55A722B3AAF3005C792D /* Data+ReadableHash.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+ReadableHash.swift"; sourceTree = "<group>"; };
 		F1E148C0207BAECF00F81833 /* ios-test-host.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "ios-test-host.xcconfig"; sourceTree = "<group>"; };
 		F1E148C2207BAED000F81833 /* tests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = tests.xcconfig; sourceTree = "<group>"; };
 		F1E148C4207BAED000F81833 /* project-debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "project-debug.xcconfig"; sourceTree = "<group>"; };
@@ -694,6 +696,7 @@
 				BFBAE9DA1E01A8F2003FCE49 /* String+Emoji.swift */,
 				5E4BC1C5218C830500A8682E /* String+Spaces.swift */,
 				F19E554C22AFDC8D005C792D /* String+ReadableHash.swift */,
+				F19E55A722B3AAF3005C792D /* Data+ReadableHash.swift */,
 				870FFA811D82B73B007E9806 /* Data+ZMSCrypto.swift */,
 				877F501C1E719B2B00894C90 /* String+ExtremeCombiningCharacters.swift */,
 				163FB9071F22302C00802AF4 /* DispatchGroupQueue.swift */,
@@ -1046,6 +1049,7 @@
 				EF18C7D21F9E37CA0085A832 /* String+Filename.swift in Sources */,
 				54181A541F594F6B00155ABC /* FileManager+Protection.swift in Sources */,
 				097E36C31B7B62150039CC4C /* NSLocale+Internal.m in Sources */,
+				F19E55A822B3AAF3005C792D /* Data+ReadableHash.swift in Sources */,
 				BF3A7A601D8AA9B30034FF40 /* OptionalComparison.swift in Sources */,
 				BFBAE9DB1E01A8F2003FCE49 /* String+Emoji.swift in Sources */,
 				F19E554D22AFDC8D005C792D /* String+ReadableHash.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Issues

We sometimes want to anonymise a string while keeping the possibility to compare them, e.g. user identifiers in logs.

### Solutions

We hash the string with SHA256 and trim to 8 characters which makes it somewhat readable while still avoiding duplicates.

