### PR TITLE
fix: failed testThatUnownedObjectIsInvalidIfValueDoesNotExistAnymore

### DIFF
--- a/Tests/Source/UnownedObjectTests.swift
+++ b/Tests/Source/UnownedObjectTests.swift
@@ -20,7 +20,7 @@
 import XCTest
 import WireUtilities
 
-class UnownedObjectTests: XCTestCase {
+final class UnownedObjectTests: XCTestCase {
 
     
     func testThatCreatingAnUnownedObjectWithALocallyScopedObjectIsValid() {
@@ -33,7 +33,7 @@ class UnownedObjectTests: XCTestCase {
     
     func testThatUnownedObjectIsInvalidIfValueDoesNotExistAnymore() {
         
-        var array : Array<Date>? = [Date()]
+        var array : Array<NSObject>? = [NSObject()]
         let unownedObject = UnownedObject(array![0] as AnyObject)
         array = nil
         XCTAssertFalse(unownedObject.isValid)


### PR DESCRIPTION
## What's new in this PR?

### Issues

After upgraded to Xcode 11, `testThatUnownedObjectIsInvalidIfValueDoesNotExistAnymore` fails.

### Causes

`Date` is no longer a object in Xcode 11 and not suitable for testing `UnownedObject `

### Solutions

Replace it with `NSObject`