### PR TITLE
[Refactor] Add Keychain extension for the fetching passcode

### DIFF
--- a/Source/Keychain/Keychain+Passcode.swift
+++ b/Source/Keychain/Keychain+Passcode.swift
@@ -1,0 +1,37 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import Foundation
+
+public extension Keychain {
+    static func deletePasscode() {
+        try? Keychain.deleteItem(PasscodeKeychainItem.passcode)
+    }
+
+    static func fetchPasscode() -> Data? {
+        let data = try? Keychain.fetchItem(PasscodeKeychainItem.passcode)
+
+        if data?.isEmpty == true {
+            return nil
+        }
+
+        return data
+    }
+}
+

--- a/Source/Keychain/PasscodeKeychainItem.swift
+++ b/Source/Keychain/PasscodeKeychainItem.swift
@@ -1,0 +1,54 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+public enum PasscodeKeychainItem: KeychainItem {
+
+    case passcode
+
+    public var uniqueIdentifier: String {
+        return "com.wire.passcode"
+    }
+
+    public var queryForGettingValue: [CFString: Any] {
+        let query: [CFString: Any]
+
+        switch self {
+        case .passcode:
+            query = [kSecClass: kSecClassGenericPassword,
+                     kSecAttrAccount: uniqueIdentifier,
+                     kSecReturnData: true]
+        }
+
+        return query
+    }
+
+    public func queryForSetting(value: Data) -> [CFString: Any] {
+        let query: [CFString: Any]
+
+        switch self {
+        case .passcode:
+            query = [kSecClass: kSecClassGenericPassword,
+                     kSecAttrAccount: uniqueIdentifier,
+                     kSecValueData: value]
+        }
+
+        return query
+    }
+}

--- a/WireUtilities.xcodeproj/project.pbxproj
+++ b/WireUtilities.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		06B2BA8F2577FD76006D4011 /* Keychain+Passcode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06B2BA8E2577FD76006D4011 /* Keychain+Passcode.swift */; };
+		06B2BA912577FDB2006D4011 /* PasscodeKeychainItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06B2BA902577FDB2006D4011 /* PasscodeKeychainItem.swift */; };
 		097E36C31B7B62150039CC4C /* NSLocale+Internal.m in Sources */ = {isa = PBXBuildFile; fileRef = 097E36C21B7B62150039CC4C /* NSLocale+Internal.m */; };
 		097E36C51B7B631C0039CC4C /* NSLocale+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 097E36C41B7B631C0039CC4C /* NSLocale+Internal.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		09F027CB1B721D7300BADDB6 /* NSUserDefaults+SharedUserDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = 09F027C81B721D7300BADDB6 /* NSUserDefaults+SharedUserDefaults.m */; };
@@ -248,6 +250,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		06B2BA8E2577FD76006D4011 /* Keychain+Passcode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Keychain+Passcode.swift"; sourceTree = "<group>"; };
+		06B2BA902577FDB2006D4011 /* PasscodeKeychainItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasscodeKeychainItem.swift; sourceTree = "<group>"; };
 		097E36C21B7B62150039CC4C /* NSLocale+Internal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSLocale+Internal.m"; sourceTree = "<group>"; };
 		097E36C41B7B631C0039CC4C /* NSLocale+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSLocale+Internal.h"; sourceTree = "<group>"; };
 		09F027C81B721D7300BADDB6 /* NSUserDefaults+SharedUserDefaults.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSUserDefaults+SharedUserDefaults.m"; sourceTree = "<group>"; };
@@ -599,7 +603,7 @@
 				16B75F65222EDC5000DCAFF2 /* String+Stripping.swift */,
 				5E9EA4C022423E0300D401B2 /* Array+SafeIndex.swift */,
 				632378692508D34D00AD4346 /* Array+Shift.swift */,
-        EE16270F250BA12900D35062 /* VolatileData.swift */,
+				EE16270F250BA12900D35062 /* VolatileData.swift */,
 				5E39FC53225B37EC00C682B8 /* Password */,
 			);
 			path = Source;
@@ -739,6 +743,8 @@
 			isa = PBXGroup;
 			children = (
 				A9A3B1EF24D9814D001AF38E /* Keychain.swift */,
+				06B2BA8E2577FD76006D4011 /* Keychain+Passcode.swift */,
+				06B2BA902577FDB2006D4011 /* PasscodeKeychainItem.swift */,
 			);
 			path = Keychain;
 			sourceTree = "<group>";
@@ -1120,6 +1126,7 @@
 				543B04A11BC6B693008C2912 /* NSData+ZMSCrypto.m in Sources */,
 				5EE020C7214A9FC5001669F0 /* ZMAtomicInteger.m in Sources */,
 				6323786A2508D34D00AD4346 /* Array+Shift.swift in Sources */,
+				06B2BA912577FDB2006D4011 /* PasscodeKeychainItem.swift in Sources */,
 				D504CD372090CB2900A78DAA /* Flip.swift in Sources */,
 				163FB9081F22302C00802AF4 /* DispatchGroupQueue.swift in Sources */,
 				54CA31291B74F36B00B820C0 /* Functional.swift in Sources */,
@@ -1138,6 +1145,7 @@
 				870FFA821D82B73B007E9806 /* Data+ZMSCrypto.swift in Sources */,
 				D53DB99F203ED59C00655CB4 /* Result.swift in Sources */,
 				A9CDCDC2237D9928008A9BC6 /* UIColor+Hex.swift in Sources */,
+				06B2BA8F2577FD76006D4011 /* Keychain+Passcode.swift in Sources */,
 				8735AE6F2035E3BC00DCE66E /* StringLengthValidator.swift in Sources */,
 				F9479C751E4A2D0F0039F55F /* NSOrderedSet.swift in Sources */,
 				EE1E354221E7739400F1144B /* DarwinNotificationCenter.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

 Move the `Keychain` extension from the UI because we need it in the Data Model.

- **Why do we need it in the Data Model?**
There is a new protocol `ApplockType` which contains a `isCustomPasscodeNotSet` property.  We need a method to fetch the passcode from the `Keychain`.
```
var isCustomPasscodeNotSet: Bool {
        return config.useCustomCodeInsteadOfAccountPassword && Keychain.fetchPasscode() == nil
 }
```

## Dependencies

https://github.com/wireapp/wire-ios-data-model/pull/1081