### PR TITLE
UTI Helper

### DIFF
--- a/Source/Public/UTType.swift
+++ b/Source/Public/UTType.swift
@@ -46,6 +46,7 @@ public enum UTTagClass {
  * A wrapper around Uniform Type Identifiers.
  */
 
+@available(iOS, deprecated:14.0, message: "use UniformTypeIdentifiers.UTType instead")
 public struct UTType: Equatable {
 
     /// The raw string value to use with the C UTType API.

--- a/Source/UTIHelper.swift
+++ b/Source/UTIHelper.swift
@@ -107,7 +107,7 @@ public final class UTIHelper: NSObject {
             if utType == nil {
                 
                 let imageTypes: [UniformTypeIdentifiers.UTType] = [.jpeg, .gif, .png, .json, .svg]
-                for type in imageTypes{
+                for type in imageTypes {
                     if mime == type.mimeType {
                         utType = type
                         break

--- a/Source/UTIHelper.swift
+++ b/Source/UTIHelper.swift
@@ -1,0 +1,69 @@
+//
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import Foundation
+import UniformTypeIdentifiers
+import CoreServices
+
+@objc
+public final class UTIHelper: NSObject {
+    
+    @objc
+    public class func convertToMime(uti: String) -> String? {
+        
+        let mimeType: String
+        if #available(iOS 14, *) {
+            guard let utType = UniformTypeIdentifiers.UTType(uti) else {
+                return nil
+            }
+
+            if let preferredMIMEType = utType.preferredMIMEType {
+                mimeType = preferredMIMEType
+            } else {
+                #if targetEnvironment(simulator)
+                ///HACK: hard code MIME when preferredMIMEType is nil for M1 simulator, we should file a ticket to apple for this issue
+                switch utType {
+                case .jpeg:
+                    mimeType = "image/jpeg"
+                case .png:
+                    mimeType = "image/png"
+                case .gif:
+                    mimeType = "image/gif"
+                default:
+                    return nil
+                }
+                #else
+                return nil
+                #endif
+            }
+
+        } else {
+            let unmanagedMime = UTTypeCopyPreferredTagWithClass(uti as CFString, kUTTagClassMIMEType)
+            
+            guard let retainedValue = unmanagedMime?.takeRetainedValue() else {
+                return nil
+            }
+
+            mimeType = retainedValue as String
+        }
+
+        return mimeType
+    }
+
+}

--- a/Source/UTIHelper.swift
+++ b/Source/UTIHelper.swift
@@ -16,21 +16,20 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
 import UniformTypeIdentifiers
 import CoreServices
 
 @objc
 public final class UTIHelper: NSObject {
-    
+
     @objc
     public class func conformsToImageType(uti: String) -> Bool {
         if #available(iOS 14, *) {
             guard let utType = UniformTypeIdentifiers.UTType(uti) else {
                 return false
             }
-            
+
             return utType.conforms(to: .image) ||
                     utType.conforms(to: .png) ||
                     utType.conforms(to: .jpeg) ||
@@ -40,14 +39,14 @@ public final class UTIHelper: NSObject {
             return UTTypeConformsTo(mimeType as CFString, kUTTypeImage)
         }
     }
-    
+
     @objc
     public class func conformsToVectorType(uti: String) -> Bool {
         if #available(iOS 14, *) {
             guard let utType = UniformTypeIdentifiers.UTType(uti) else {
                 return false
             }
-                        
+
             return utType.conforms(to: UniformTypeIdentifiers.UTType.svg)
         } else {
             guard let mimeType = convertToMime(uti: uti) else { return false }
@@ -61,7 +60,7 @@ public final class UTIHelper: NSObject {
             guard let utType = UniformTypeIdentifiers.UTType(uti) else {
                 return false
             }
-                        
+
             return utType.conforms(to: UniformTypeIdentifiers.UTType.json)
         } else {
             guard let mimeType = convertToMime(uti: uti) else { return false }
@@ -74,9 +73,9 @@ public final class UTIHelper: NSObject {
         if #available(iOS 14, *) {
             var utType: UniformTypeIdentifiers.UTType?
             utType = UniformTypeIdentifiers.UTType(mimeType: mime)
-            
+
             #if targetEnvironment(simulator)
-            ///HACK: hard code MIME when preferredMIMEType is nil for M1 simulator, we should file a ticket to apple for this issue
+            /// HACK: hard code MIME when preferredMIMEType is nil for M1 simulator, we should file a ticket to apple for this issue
             if utType == nil {
                 switch mime {
                 case "image/jpeg":
@@ -96,25 +95,25 @@ public final class UTIHelper: NSObject {
             return utType?.identifier
         } else {
             let cfString = UTTypeCreatePreferredIdentifierForTag(mime as CFString, kUTTagClassMIMEType as CFString, nil)?.takeRetainedValue()
-            
+
             return cfString as String?
         }
     }
-    
+
     @objc
     public class func convertToMime(uti: String) -> String? {
-        
+
         let mimeType: String
         if #available(iOS 14, *) {
             guard let utType = UniformTypeIdentifiers.UTType(uti) else {
                 return nil
             }
-            
+
             if let preferredMIMEType = utType.preferredMIMEType {
                 mimeType = preferredMIMEType
             } else {
                 #if targetEnvironment(simulator)
-                ///HACK: hard code MIME when preferredMIMEType is nil for M1 simulator, we should file a ticket to apple for this issue
+                /// HACK: hard code MIME when preferredMIMEType is nil for M1 simulator, we should file a ticket to apple for this issue
                 switch utType {
                 case .jpeg:
                     mimeType = "image/jpeg"
@@ -131,18 +130,18 @@ public final class UTIHelper: NSObject {
                 return nil
                 #endif
             }
-            
+
         } else {
             let unmanagedMime = UTTypeCopyPreferredTagWithClass(uti as CFString, kUTTagClassMIMEType)
-            
+
             guard let retainedValue = unmanagedMime?.takeRetainedValue() else {
                 return nil
             }
-            
+
             mimeType = retainedValue as String
         }
-        
+
         return mimeType
     }
-    
+
 }

--- a/Source/UTIHelper.swift
+++ b/Source/UTIHelper.swift
@@ -31,7 +31,7 @@ public final class UTIHelper: NSObject {
                 return false
             }
 
-            return utType.conforms(to: UniformTypeIdentifiers.UTType.image) ////TODO: jpeg return false here
+            return utType.conforms(to: UniformTypeIdentifiers.UTType.image) || utType.conforms(to: UniformTypeIdentifiers.UTType.jpeg)
         } else {
             guard let mimeType = convertToMime(uti: uti) else { return false }
             return UTTypeConformsTo(mimeType as CFString, kUTTypeImage)

--- a/Source/UTIHelper.swift
+++ b/Source/UTIHelper.swift
@@ -45,6 +45,8 @@ public final class UTIHelper: NSObject {
                     mimeType = "image/png"
                 case .gif:
                     mimeType = "image/gif"
+                case .json:
+                    mimeType = "application/json"
                 default:
                     return nil
                 }

--- a/Source/UTIHelper.swift
+++ b/Source/UTIHelper.swift
@@ -96,8 +96,8 @@ public final class UTIHelper: NSObject {
             return utType?.identifier
         } else {
             return UTTypeCreatePreferredIdentifierForTag(kUTTagClassMIMEType,
-                                                                 mime as CFString,
-                                                                 kUTTypeContent)?.takeRetainedValue() as String?
+                                                         mime as CFString,
+                                                         kUTTypeContent)?.takeRetainedValue() as String?
         }
     }
 

--- a/Source/UTIHelper.swift
+++ b/Source/UTIHelper.swift
@@ -39,9 +39,7 @@ public final class UTIHelper: NSObject {
             return utType.conforms(to: .image)
             #endif
         } else {
-            guard let mimeType = convertToMime(uti: uti) else { return false }
-            
-            return UTTypeConformsTo(mimeType as CFString, kUTTypeImage)
+            return UTTypeConformsTo(uti as CFString, kUTTypeImage)
         }
     }
 
@@ -54,12 +52,10 @@ public final class UTIHelper: NSObject {
 
             return utType.conforms(to: UniformTypeIdentifiers.UTType.svg)
         } else {
-            guard let mimeType = convertToMime(uti: uti) else { return false }
-            
-            return UTTypeConformsTo(mimeType as CFString, kUTTypeScalableVectorGraphics)
+            return UTTypeConformsTo(uti as CFString, kUTTypeScalableVectorGraphics)
         }
     }
-
+    
     @objc
     public class func conformsToJsonType(uti: String) -> Bool {
         if #available(iOS 14, *) {
@@ -69,8 +65,7 @@ public final class UTIHelper: NSObject {
 
             return utType.conforms(to: UniformTypeIdentifiers.UTType.json)
         } else {
-            guard let mimeType = convertToMime(uti: uti) else { return false }
-            return UTTypeConformsTo(mimeType as CFString, kUTTypeJSON)
+            return UTTypeConformsTo(uti as CFString, kUTTypeJSON)
         }
     }
 

--- a/Source/UTIHelper.swift
+++ b/Source/UTIHelper.swift
@@ -32,9 +32,9 @@ public final class UTIHelper: NSObject {
             }
             
             return utType.conforms(to: .image) ||
-//                utType.isSubtype(of: .image)
-            utType.conforms(to: .jpeg) ||
-            utType.conforms(to: .gif)
+                    utType.conforms(to: .png) ||
+                    utType.conforms(to: .jpeg) ||
+                    utType.conforms(to: .gif)
         } else {
             guard let mimeType = convertToMime(uti: uti) else { return false }
             return UTTypeConformsTo(mimeType as CFString, kUTTypeImage)
@@ -54,7 +54,21 @@ public final class UTIHelper: NSObject {
             return UTTypeConformsTo(mimeType as CFString, kUTTypeScalableVectorGraphics)
         }
     }
-    
+
+    @objc
+    public class func conformsToJsonType(uti: String) -> Bool {
+        if #available(iOS 14, *) {
+            guard let utType = UniformTypeIdentifiers.UTType(uti) else {
+                return false
+            }
+                        
+            return utType.conforms(to: UniformTypeIdentifiers.UTType.json)
+        } else {
+            guard let mimeType = convertToMime(uti: uti) else { return false }
+            return UTTypeConformsTo(mimeType as CFString, kUTTypeScalableVectorGraphics)
+        }
+    }
+
     @objc
     public class func convertToUti(mime: String) -> String? {
         if #available(iOS 14, *) {
@@ -69,6 +83,10 @@ public final class UTIHelper: NSObject {
                     utType = .jpeg
                 case "image/gif":
                     utType = .gif
+                case "image/png":
+                    utType = .png
+                case "application/json":
+                    utType = .json
                 default:
                     break
                 }

--- a/Source/UTIHelper.swift
+++ b/Source/UTIHelper.swift
@@ -23,6 +23,20 @@ import CoreServices
 
 @objc
 public final class UTIHelper: NSObject {
+
+    @objc
+    public class func conformsToImageType(uti: String) -> Bool {
+        if #available(iOS 14, *) {
+            guard let utType = UniformTypeIdentifiers.UTType(uti) else {
+                return false
+            }
+
+            return utType.conforms(to: UniformTypeIdentifiers.UTType.image) ////TODO: jpeg return false here
+        } else {
+            guard let mimeType = convertToMime(uti: uti) else { return false }
+            return UTTypeConformsTo(mimeType as CFString, kUTTypeImage)
+        }
+    }
     
     @objc
     public class func conformsToVectorType(uti: String) -> Bool {

--- a/Source/UTIHelper.swift
+++ b/Source/UTIHelper.swift
@@ -25,6 +25,20 @@ import CoreServices
 public final class UTIHelper: NSObject {
     
     @objc
+    public class func conformsToVectorType(mimeType: String) -> Bool {
+        if #available(iOS 14, *) {
+            guard let utType = UniformTypeIdentifiers.UTType(mimeType: mimeType) else {
+                return false
+            }
+
+            return utType.conforms(to: UniformTypeIdentifiers.UTType.svg)
+        } else {
+            return UTTypeConformsTo(mimeType as CFString, kUTTypeScalableVectorGraphics)
+        }
+    }
+
+    
+    @objc
     public class func convertToMime(uti: String) -> String? {
         
         let mimeType: String

--- a/Source/UTIHelper.swift
+++ b/Source/UTIHelper.swift
@@ -40,6 +40,7 @@ public final class UTIHelper: NSObject {
             #endif
         } else {
             guard let mimeType = convertToMime(uti: uti) else { return false }
+            
             return UTTypeConformsTo(mimeType as CFString, kUTTypeImage)
         }
     }
@@ -54,6 +55,7 @@ public final class UTIHelper: NSObject {
             return utType.conforms(to: UniformTypeIdentifiers.UTType.svg)
         } else {
             guard let mimeType = convertToMime(uti: uti) else { return false }
+            
             return UTTypeConformsTo(mimeType as CFString, kUTTypeScalableVectorGraphics)
         }
     }
@@ -68,7 +70,7 @@ public final class UTIHelper: NSObject {
             return utType.conforms(to: UniformTypeIdentifiers.UTType.json)
         } else {
             guard let mimeType = convertToMime(uti: uti) else { return false }
-            return UTTypeConformsTo(mimeType as CFString, kUTTypeScalableVectorGraphics)
+            return UTTypeConformsTo(mimeType as CFString, kUTTypeJSON)
         }
     }
 
@@ -98,9 +100,9 @@ public final class UTIHelper: NSObject {
 
             return utType?.identifier
         } else {
-            let cfString = UTTypeCreatePreferredIdentifierForTag(mime as CFString, kUTTagClassMIMEType as CFString, nil)?.takeRetainedValue()
-
-            return cfString as String?
+            return UTTypeCreatePreferredIdentifierForTag(kUTTagClassMIMEType,
+                                                                 mime as CFString,
+                                                                 kUTTypeContent)?.takeRetainedValue() as String?
         }
     }
 

--- a/Source/UTIHelper.swift
+++ b/Source/UTIHelper.swift
@@ -29,11 +29,15 @@ public final class UTIHelper: NSObject {
             guard let utType = UniformTypeIdentifiers.UTType(uti) else {
                 return false
             }
-
+            #if targetEnvironment(simulator)
+            //HACK: arm64 simulator return false for utType.conforms(to: .image), but add additional subtype check works
             return utType.conforms(to: .image) ||
-                    utType.conforms(to: .png) ||
-                    utType.conforms(to: .jpeg) ||
-                    utType.conforms(to: .gif)
+                                utType.conforms(to: .png) ||
+                                utType.conforms(to: .jpeg) ||
+                                utType.conforms(to: .gif)
+            #else
+            return utType.conforms(to: .image)
+            #endif
         } else {
             guard let mimeType = convertToMime(uti: uti) else { return false }
             return UTTypeConformsTo(mimeType as CFString, kUTTypeImage)

--- a/Source/UTIHelper.swift
+++ b/Source/UTIHelper.swift
@@ -25,14 +25,15 @@ import CoreServices
 public final class UTIHelper: NSObject {
     
     @objc
-    public class func conformsToVectorType(mimeType: String) -> Bool {
+    public class func conformsToVectorType(uti: String) -> Bool {
         if #available(iOS 14, *) {
-            guard let utType = UniformTypeIdentifiers.UTType(mimeType: mimeType) else {
+            guard let utType = UniformTypeIdentifiers.UTType(uti) else {
                 return false
             }
 
             return utType.conforms(to: UniformTypeIdentifiers.UTType.svg)
         } else {
+            guard let mimeType = convertToMime(uti: uti) else { return false }
             return UTTypeConformsTo(mimeType as CFString, kUTTypeScalableVectorGraphics)
         }
     }

--- a/Tests/UTIHelperTests.swift
+++ b/Tests/UTIHelperTests.swift
@@ -17,6 +17,9 @@
 //
 
 import XCTest
+import UniformTypeIdentifiers
+import CoreServices
+@testable import WireUtilities
 
 final class UTIHelperTests: XCTestCase {
 

--- a/Tests/UTIHelperTests.swift
+++ b/Tests/UTIHelperTests.swift
@@ -1,66 +1,69 @@
 //
-//  UTIHelperTests.swift
-//  WireUtilities-Tests
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
 //
-//  Created by bill on 02.08.21.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
 import XCTest
 
 final class UTIHelperTests: XCTestCase {
-    
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-    
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-    
+
     func testThatconformsToVectorTypeIdentifiesSVG() {
-        //given, when, then
+        // given, when, then
         XCTAssert(UTIHelper.conformsToVectorType(uti: "public.svg-image"))
     }
-    
+
     func testThatConformsTypeIdentifiesJSONIsNotImageOrVectorType() {
-        //given
+        // given
         let sut = "public.json"
-        
-        //when & then
+
+        // when & then
         XCTAssertFalse(UTIHelper.conformsToImageType(uti: sut))
         XCTAssertFalse(UTIHelper.conformsToVectorType(uti: sut))
-        
+
         XCTAssert(UTIHelper.conformsToJsonType(uti: sut))
     }
-    
+
     func testThatConformsToImageTypeIdentifiesCommonImageTypes() {
-        //given
+        // given
         let suts = ["public.jpeg",
                     "com.compuserve.gif",
                     "public.png",
                     "public.svg-image"]
-        
-        suts.forEach() { sut in
-            //when & then
+
+        suts.forEach { sut in
+            // when & then
             XCTAssert(UTIHelper.conformsToImageType(uti: sut), "\(sut) does not conorms to image type")
         }
     }
-    
+
     func testThatConvertToUtiConvertsCommonImageTypes() {
-        
-        //given & when & then
+
+        // given & when & then
         XCTAssertEqual(UTIHelper.convertToUti(mime: "image/jpeg"), "public.jpeg")
         XCTAssertEqual(UTIHelper.convertToUti(mime: "image/gif"), "com.compuserve.gif")
         XCTAssertEqual(UTIHelper.convertToUti(mime: "image/png"), "public.png")
         XCTAssertEqual(UTIHelper.convertToUti(mime: "image/svg+xml"), "public.svg-image")
     }
-    
+
     func testThatConvertToMimeConvertsCommonImageTypes() {
-        //given & when & then
+        // given & when & then
         XCTAssertEqual(UTIHelper.convertToMime(uti: "public.jpeg"), "image/jpeg")
         XCTAssertEqual(UTIHelper.convertToMime(uti: "com.compuserve.gif"), "image/gif")
         XCTAssertEqual(UTIHelper.convertToMime(uti: "public.png"), "image/png")
         XCTAssertEqual(UTIHelper.convertToMime(uti: "public.svg-image"), "image/svg+xml")
-                
+
     }
 }

--- a/Tests/UTIHelperTests.swift
+++ b/Tests/UTIHelperTests.swift
@@ -1,0 +1,66 @@
+//
+//  UTIHelperTests.swift
+//  WireUtilities-Tests
+//
+//  Created by bill on 02.08.21.
+//
+
+import XCTest
+
+final class UTIHelperTests: XCTestCase {
+    
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+    
+    func testThatconformsToVectorTypeIdentifiesSVG() {
+        //given, when, then
+        XCTAssert(UTIHelper.conformsToVectorType(uti: "public.svg-image"))
+    }
+    
+    func testThatConformsTypeIdentifiesJSONIsNotImageOrVectorType() {
+        //given
+        let sut = "public.json"
+        
+        //when & then
+        XCTAssertFalse(UTIHelper.conformsToImageType(uti: sut))
+        XCTAssertFalse(UTIHelper.conformsToVectorType(uti: sut))
+        
+        XCTAssert(UTIHelper.conformsToJsonType(uti: sut))
+    }
+    
+    func testThatConformsToImageTypeIdentifiesCommonImageTypes() {
+        //given
+        let suts = ["public.jpeg",
+                    "com.compuserve.gif",
+                    "public.png",
+                    "public.svg-image"]
+        
+        suts.forEach() { sut in
+            //when & then
+            XCTAssert(UTIHelper.conformsToImageType(uti: sut), "\(sut) does not conorms to image type")
+        }
+    }
+    
+    func testThatConvertToUtiConvertsCommonImageTypes() {
+        
+        //given & when & then
+        XCTAssertEqual(UTIHelper.convertToUti(mime: "image/jpeg"), "public.jpeg")
+        XCTAssertEqual(UTIHelper.convertToUti(mime: "image/gif"), "com.compuserve.gif")
+        XCTAssertEqual(UTIHelper.convertToUti(mime: "image/png"), "public.png")
+        XCTAssertEqual(UTIHelper.convertToUti(mime: "image/svg+xml"), "public.svg-image")
+    }
+    
+    func testThatConvertToMimeConvertsCommonImageTypes() {
+        //given & when & then
+        XCTAssertEqual(UTIHelper.convertToMime(uti: "public.jpeg"), "image/jpeg")
+        XCTAssertEqual(UTIHelper.convertToMime(uti: "com.compuserve.gif"), "image/gif")
+        XCTAssertEqual(UTIHelper.convertToMime(uti: "public.png"), "image/png")
+        XCTAssertEqual(UTIHelper.convertToMime(uti: "public.svg-image"), "image/svg+xml")
+                
+    }
+}

--- a/WireUtilities.xcodeproj/project.pbxproj
+++ b/WireUtilities.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 		A96E00E0265FEF070034A057 /* OCMock.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A944AEE8265E4D9C00164C79 /* OCMock.xcframework */; };
 		A96E00E1265FEF070034A057 /* OCMock.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A944AEE8265E4D9C00164C79 /* OCMock.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A9A3B1F024D9814D001AF38E /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9A3B1EF24D9814D001AF38E /* Keychain.swift */; };
+		A9C6EDE426B32E9D007F61C5 /* UTIHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C6EDE326B32E9D007F61C5 /* UTIHelper.swift */; };
 		A9CDCDC2237D9928008A9BC6 /* UIColor+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9CDCDC1237D9927008A9BC6 /* UIColor+Hex.swift */; };
 		A9CDCDC4237D9A14008A9BC6 /* UIColor+Mixing.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9CDCDC3237D9A14008A9BC6 /* UIColor+Mixing.swift */; };
 		A9CDCDC6237D9A6E008A9BC6 /* UIColor+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9CDCDC5237D9A6E008A9BC6 /* UIColor+Equatable.swift */; };
@@ -357,6 +358,7 @@
 		A944AEE8265E4D9C00164C79 /* OCMock.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = OCMock.xcframework; path = Carthage/Build/OCMock.xcframework; sourceTree = "<group>"; };
 		A944AEE9265E4D9C00164C79 /* WireTesting.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = WireTesting.xcframework; path = Carthage/Build/WireTesting.xcframework; sourceTree = "<group>"; };
 		A9A3B1EF24D9814D001AF38E /* Keychain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Keychain.swift; sourceTree = "<group>"; };
+		A9C6EDE326B32E9D007F61C5 /* UTIHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIHelper.swift; sourceTree = "<group>"; };
 		A9CDCDC1237D9927008A9BC6 /* UIColor+Hex.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "UIColor+Hex.swift"; path = "Source/Public/UIColor+Hex.swift"; sourceTree = SOURCE_ROOT; };
 		A9CDCDC3237D9A14008A9BC6 /* UIColor+Mixing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+Mixing.swift"; sourceTree = "<group>"; };
 		A9CDCDC5237D9A6E008A9BC6 /* UIColor+Equatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+Equatable.swift"; sourceTree = "<group>"; };
@@ -574,6 +576,7 @@
 				5E9EA4C022423E0300D401B2 /* Array+SafeIndex.swift */,
 				632378692508D34D00AD4346 /* Array+Shift.swift */,
 				EE16270F250BA12900D35062 /* VolatileData.swift */,
+				A9C6EDE326B32E9D007F61C5 /* UTIHelper.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -1031,6 +1034,7 @@
 				A9A3B1F024D9814D001AF38E /* Keychain.swift in Sources */,
 				7C8BFFE522FD611700B3C8A5 /* ZMEmailAddressValidator.swift in Sources */,
 				7C8BFFE322FD5D9600B3C8A5 /* ZMAccentColorValidator.swift in Sources */,
+				A9C6EDE426B32E9D007F61C5 /* UTIHelper.swift in Sources */,
 				097E36C31B7B62150039CC4C /* NSLocale+Internal.m in Sources */,
 				F19E55A822B3AAF3005C792D /* Data+ReadableHash.swift in Sources */,
 				BF3A7A601D8AA9B30034FF40 /* OptionalComparison.swift in Sources */,

--- a/WireUtilities.xcodeproj/project.pbxproj
+++ b/WireUtilities.xcodeproj/project.pbxproj
@@ -123,6 +123,7 @@
 		A96755D9265FE98A0062EDC5 /* WireTesting.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A944AEE9265E4D9C00164C79 /* WireTesting.xcframework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		A96E00E0265FEF070034A057 /* OCMock.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A944AEE8265E4D9C00164C79 /* OCMock.xcframework */; };
 		A96E00E1265FEF070034A057 /* OCMock.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A944AEE8265E4D9C00164C79 /* OCMock.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		A98EC2A726B8169700D10C80 /* UTIHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98EC2A626B8169700D10C80 /* UTIHelperTests.swift */; };
 		A9A3B1F024D9814D001AF38E /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9A3B1EF24D9814D001AF38E /* Keychain.swift */; };
 		A9C6EDE426B32E9D007F61C5 /* UTIHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C6EDE326B32E9D007F61C5 /* UTIHelper.swift */; };
 		A9CDCDC2237D9928008A9BC6 /* UIColor+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9CDCDC1237D9927008A9BC6 /* UIColor+Hex.swift */; };
@@ -357,6 +358,7 @@
 		A944AEE7265E4D9B00164C79 /* WireSystem.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = WireSystem.xcframework; path = Carthage/Build/WireSystem.xcframework; sourceTree = "<group>"; };
 		A944AEE8265E4D9C00164C79 /* OCMock.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = OCMock.xcframework; path = Carthage/Build/OCMock.xcframework; sourceTree = "<group>"; };
 		A944AEE9265E4D9C00164C79 /* WireTesting.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = WireTesting.xcframework; path = Carthage/Build/WireTesting.xcframework; sourceTree = "<group>"; };
+		A98EC2A626B8169700D10C80 /* UTIHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIHelperTests.swift; sourceTree = "<group>"; };
 		A9A3B1EF24D9814D001AF38E /* Keychain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Keychain.swift; sourceTree = "<group>"; };
 		A9C6EDE326B32E9D007F61C5 /* UTIHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIHelper.swift; sourceTree = "<group>"; };
 		A9CDCDC1237D9927008A9BC6 /* UIColor+Hex.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "UIColor+Hex.swift"; path = "Source/Public/UIColor+Hex.swift"; sourceTree = SOURCE_ROOT; };
@@ -807,6 +809,7 @@
 				5E9EA4C222423EA600D401B2 /* ArraySafeIndexTests.swift */,
 				EF2AFC9E228179C2008C921A /* UUID+DataTests.swift */,
 				6323786B2508D51C00AD4346 /* ArrayShiftTests.swift */,
+				A98EC2A626B8169700D10C80 /* UTIHelperTests.swift */,
 			);
 			name = Source;
 			sourceTree = "<group>";
@@ -1124,6 +1127,7 @@
 				F9D381B01B70B94300E6E4EB /* ZMFunctionalTests.m in Sources */,
 				BFA2F03920C9490500EBE97C /* FunctionOperatorTests.swift in Sources */,
 				54A3430E1E4B7DFB00B48A0F /* NSOrderedSetTests.swift in Sources */,
+				A98EC2A726B8169700D10C80 /* UTIHelperTests.swift in Sources */,
 				54FA8E821BC6CC3400E42980 /* NSData+ZMSCryptoTests.swift in Sources */,
 				BF9D0B061F1CF39A005D4C31 /* Optional+ApplyTests.swift in Sources */,
 				EE162712250BA6E600D35062 /* VolatileDataTests.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

Create `UTIHelper` to replace deprecated `UTTypeConformsTo` and `UTTypeCopyPreferredTagWithClass` method

### TODO
remove `UTType` struct after iOS 13 is dropped.
- [ ] create a test plan for run the new tests with iOS 12/13 simulators