### PR TITLE
data mimetype helper

### DIFF
--- a/Source/Public/Data+Image.swift
+++ b/Source/Public/Data+Image.swift
@@ -21,6 +21,8 @@ import Foundation
 import ImageIO
 
 extension Data {
+    
+    /// get MIME type of given image data. Returns nil if the data is not a image
     public var mimeType: String? {
         guard let source = (self as NSData).imageSource,
               let type = CGImageSourceGetType(source) as String? else {

--- a/Source/Public/Data+Image.swift
+++ b/Source/Public/Data+Image.swift
@@ -21,14 +21,39 @@ import Foundation
 import ImageIO
 
 extension NSData {
+    var imageSource: CGImageSource? {
+        guard length > 0 else {
+            return nil
+        }
+        
+        return CGImageSourceCreateWithData(self as CFData, nil)
+    }
+
+    
+    /// return UTI Type of a CGImageSource
+    /// - Parameter source: a CGImageSource
+    /// - Returns: UTI type string, nullable
+    static func imageSourceType(source: CGImageSource) -> String? {
+        return CGImageSourceGetType(source) as String?
+    }
+    
+    public var mimeType: String? {
+        guard let source = CGImageSourceCreateWithData(self as CFData, nil),
+              let type = NSData.imageSourceType(source: source) else {
+            return nil
+        }
+        
+        return UTIHelper.convertToMime(uti: type)
+    }
+
+    
     /// Returns whether the data represents animated GIF
     /// - Parameter data: image data
     /// - Returns: returns turn if the data is GIF and number of images > 1
     @objc
     public func isDataAnimatedGIF() -> Bool {
-        guard length > 0,
-              let source = CGImageSourceCreateWithData(self as CFData, nil),
-              let type = CGImageSourceGetType(source) as String? else {
+        guard let source = CGImageSourceCreateWithData(self as CFData, nil),
+              let type = NSData.imageSourceType(source: source) else {
             return false
         }
         

--- a/Source/Public/Data+Image.swift
+++ b/Source/Public/Data+Image.swift
@@ -22,7 +22,7 @@ import ImageIO
 
 extension Data {
     public var mimeType: String? {
-        guard let source = CGImageSourceCreateWithData(self as CFData, nil),
+        guard let source = (self as NSData).imageSource,
               let type = CGImageSourceGetType(source) as String? else {
             return nil
         }
@@ -45,15 +45,13 @@ extension NSData {
     /// - Returns: returns turn if the data is GIF and number of images > 1
     @objc
     public func isDataAnimatedGIF() -> Bool {
-        guard let source = CGImageSourceCreateWithData(self as CFData, nil),
-              let type = CGImageSourceGetType(source) as String? else {
-            return false
-        }
-        
-        guard UTIHelper.conformsToGifType(uti: type) else {
+        guard let source = imageSource,
+              CGImageSourceGetCount(source) > 1,
+              let type = CGImageSourceGetType(source) as String?,
+              UTIHelper.conformsToGifType(uti: type) else {
             return false
         }
 
-        return CGImageSourceGetCount(source) > 1
+        return true
     }
 }

--- a/Source/Public/Data+Image.swift
+++ b/Source/Public/Data+Image.swift
@@ -20,6 +20,17 @@
 import Foundation
 import ImageIO
 
+extension Data {
+    public var mimeType: String? {
+        guard let source = CGImageSourceCreateWithData(self as CFData, nil),
+              let type = CGImageSourceGetType(source) as String? else {
+            return nil
+        }
+        
+        return UTIHelper.convertToMime(uti: type)
+    }
+}
+
 extension NSData {
     var imageSource: CGImageSource? {
         guard length > 0 else {
@@ -28,24 +39,6 @@ extension NSData {
         
         return CGImageSourceCreateWithData(self as CFData, nil)
     }
-
-    
-    /// return UTI Type of a CGImageSource
-    /// - Parameter source: a CGImageSource
-    /// - Returns: UTI type string, nullable
-    static func imageSourceType(source: CGImageSource) -> String? {
-        return CGImageSourceGetType(source) as String?
-    }
-    
-    public var mimeType: String? {
-        guard let source = CGImageSourceCreateWithData(self as CFData, nil),
-              let type = NSData.imageSourceType(source: source) else {
-            return nil
-        }
-        
-        return UTIHelper.convertToMime(uti: type)
-    }
-
     
     /// Returns whether the data represents animated GIF
     /// - Parameter data: image data
@@ -53,7 +46,7 @@ extension NSData {
     @objc
     public func isDataAnimatedGIF() -> Bool {
         guard let source = CGImageSourceCreateWithData(self as CFData, nil),
-              let type = NSData.imageSourceType(source: source) else {
+              let type = CGImageSourceGetType(source) as String? else {
             return false
         }
         

--- a/Tests/NSData+ImageTests.swift
+++ b/Tests/NSData+ImageTests.swift
@@ -20,7 +20,7 @@ import XCTest
 
 final class NSDataImageTests: XCTestCase {
     func testThatNonAnimateGifIsIdentified() {
-        // given,
+        // given
         let sut: NSData = self.data(forResource: "not_animated", extension: "gif")! as NSData
         
         // when & then
@@ -29,11 +29,19 @@ final class NSDataImageTests: XCTestCase {
     }
 
     func testThatAnimateGifIsIdentified() {
-        // given,
+        // given
         let sut: NSData = self.data(forResource: "animated", extension: "gif")! as NSData
         
         // when & then
         XCTAssertNotNil(sut)
         XCTAssert(sut.isDataAnimatedGIF())
+    }
+    
+    func testThatGifmimeTypeIsResolved() {
+        // given
+        let sut: Data = self.data(forResource: "animated", extension: "gif")!
+
+        // when & then
+        XCTAssertEqual(sut.mimeType, "image/gif")
     }
 }

--- a/Tests/NSData+ImageTests.swift
+++ b/Tests/NSData+ImageTests.swift
@@ -44,4 +44,12 @@ final class NSDataImageTests: XCTestCase {
         // when & then
         XCTAssertEqual(sut.mimeType, "image/gif")
     }
+    
+    func testThatTxtmimeTypeIsNotResolved() {
+        // given
+        let sut: Data = self.data(forResource: "excessive_diacritics", extension: "txt")!
+
+        // when & then
+        XCTAssertNil(sut.mimeType)
+    }
 }


### PR DESCRIPTION
## What's new in this PR?

Retire `ZMAssetMetaDataEncoder` form images which uses deprecated method and refactor as `Data.mimetype`