### PR TITLE
Fix: support more UTI types for movie and audio 

### DIFF
--- a/Source/UTIHelper.swift
+++ b/Source/UTIHelper.swift
@@ -144,9 +144,9 @@ public final class UTIHelper: NSObject {
         }
         if #available(iOS 14, *) {
             let audioTypes: [UTType] = [.audio, .mpeg4Audio]
-            return audioTypes.first(where: {
+            return audioTypes.contains {
                 conformsTo(uti: uti, type: $0)
-            }) != nil
+            }
         } else {
             return UTTypeConformsTo(uti as CFString, kUTTypeAudio)
         }
@@ -160,9 +160,9 @@ public final class UTIHelper: NSObject {
         if #available(iOS 14, *) {
             let movieTypes: [UTType] = [.movie, .mpeg4Movie, .quickTimeMovie]
             
-            return movieTypes.first(where: {
+            return movieTypes.contains {
                 conformsTo(uti: uti, type: $0)
-            }) != nil
+            }
         } else {
             return UTTypeConformsTo(uti as CFString, kUTTypeMovie)
         }

--- a/Source/UTIHelper.swift
+++ b/Source/UTIHelper.swift
@@ -55,6 +55,8 @@ extension UTType {
             return "text/plain"
         case .mpeg4Movie:
             return "video/mp4"
+        case .quickTimeMovie:
+            return "video/quicktime"
         default:
             return nil
         }
@@ -145,11 +147,16 @@ public final class UTIHelper: NSObject {
     }
     
     public class func conformsToMovieType(mime: String) -> Bool {
-        guard let uti = convertToUti(mime: mime) else { return false }
+        guard let uti = convertToUti(mime: mime) else {
+            return false            
+        }
         
         if #available(iOS 14, *) {
-            return conformsTo(uti: uti, type: .movie) ||
-                conformsTo(uti: uti, type: .mpeg4Movie)
+            let movieTypes: [UTType] = [.movie, .mpeg4Movie, .quickTimeMovie]
+            
+            return movieTypes.first(where: {
+                conformsTo(uti: uti, type: $0)
+            }) != nil
         } else {
             return UTTypeConformsTo(uti as CFString, kUTTypeMovie)
         }
@@ -163,7 +170,7 @@ public final class UTIHelper: NSObject {
 
     #if targetEnvironment(simulator)
     @available(iOSApplicationExtension 14.0, *)
-    private static let utTypes: [UTType] = [.jpeg, .gif, .png, .json, .svg, .mpeg4Movie, .text]
+    private static let utTypes: [UTType] = [.jpeg, .gif, .png, .json, .svg, .mpeg4Movie, .text, .quickTimeMovie]
     #endif
     
     //MARK: - converters

--- a/Source/UTIHelper.swift
+++ b/Source/UTIHelper.swift
@@ -57,6 +57,8 @@ extension UTType {
             return "video/mp4"
         case .quickTimeMovie:
             return "video/quicktime"
+        case .mpeg4Audio:
+            return "audio/mp4"
         default:
             return nil
         }
@@ -135,12 +137,16 @@ public final class UTIHelper: NSObject {
         
         return conformsToGifType(uti: uti)
     }
-    
+
     public class func conformsToAudioType(mime: String) -> Bool {
-        guard let uti = convertToUti(mime: mime) else { return false }
-        
+        guard let uti = convertToUti(mime: mime) else {
+            return false
+        }
         if #available(iOS 14, *) {
-            return conformsTo(uti: uti, type: .audio)
+            let audioTypes: [UTType] = [.audio, .mpeg4Audio]
+            return audioTypes.first(where: {
+                conformsTo(uti: uti, type: $0)
+            }) != nil
         } else {
             return UTTypeConformsTo(uti as CFString, kUTTypeAudio)
         }
@@ -148,7 +154,7 @@ public final class UTIHelper: NSObject {
     
     public class func conformsToMovieType(mime: String) -> Bool {
         guard let uti = convertToUti(mime: mime) else {
-            return false            
+            return false
         }
         
         if #available(iOS 14, *) {
@@ -170,7 +176,7 @@ public final class UTIHelper: NSObject {
 
     #if targetEnvironment(simulator)
     @available(iOSApplicationExtension 14.0, *)
-    private static let utTypes: [UTType] = [.jpeg, .gif, .png, .json, .svg, .mpeg4Movie, .text, .quickTimeMovie]
+    private static let utTypes: [UTType] = [.jpeg, .gif, .png, .json, .svg, .mpeg4Movie, .text, .quickTimeMovie, .mpeg4Audio]
     #endif
     
     //MARK: - converters

--- a/Tests/UTIHelperTests.swift
+++ b/Tests/UTIHelperTests.swift
@@ -50,6 +50,14 @@ final class UTIHelperTests: XCTestCase {
         XCTAssert(UTIHelper.conformsToMovieType(mime: sut))
     }
 
+    func testThatQuickTimeMovieConformsMovieType() {
+        // given
+        let sut = "video/quicktime"
+
+        // when & then
+        XCTAssert(UTIHelper.conformsToMovieType(mime: sut))
+    }
+
     func testThatConformsToImageTypeIdentifiesCommonImageTypes() {
         // given
         let suts = ["public.jpeg",

--- a/Tests/UTIHelperTests.swift
+++ b/Tests/UTIHelperTests.swift
@@ -66,7 +66,7 @@ final class UTIHelperTests: XCTestCase {
 
         suts.forEach { sut in
             // when & then
-            XCTAssert(UTIHelper.conformsToAudioType(mime: sut), "\(sut) does not conforms to audio type")
+            XCTAssert(UTIHelper.conformsToAudioType(mime: sut), "\(sut) does not conform to audio type")
         }
     }
 

--- a/Tests/UTIHelperTests.swift
+++ b/Tests/UTIHelperTests.swift
@@ -58,6 +58,18 @@ final class UTIHelperTests: XCTestCase {
         XCTAssert(UTIHelper.conformsToMovieType(mime: sut))
     }
 
+    func testThatCommonFilesConformsAudioType() {
+        // given
+        let suts = ["audio/mp4",
+                    "audio/mpeg",
+                    "audio/x-m4a"]
+
+        suts.forEach { sut in
+            // when & then
+            XCTAssert(UTIHelper.conformsToAudioType(mime: sut), "\(sut) does not conforms to audio type")
+        }
+    }
+
     func testThatConformsToImageTypeIdentifiesCommonImageTypes() {
         // given
         let suts = ["public.jpeg",
@@ -67,7 +79,7 @@ final class UTIHelperTests: XCTestCase {
 
         suts.forEach { sut in
             // when & then
-            XCTAssert(UTIHelper.conformsToImageType(uti: sut), "\(sut) does not conorms to image type")
+            XCTAssert(UTIHelper.conformsToImageType(uti: sut), "\(sut) does not conforms to image type")
         }
     }
 

--- a/Tests/UTIHelperTests.swift
+++ b/Tests/UTIHelperTests.swift
@@ -79,7 +79,7 @@ final class UTIHelperTests: XCTestCase {
 
         suts.forEach { sut in
             // when & then
-            XCTAssert(UTIHelper.conformsToImageType(uti: sut), "\(sut) does not conforms to image type")
+            XCTAssert(UTIHelper.conformsToImageType(uti: sut), "\(sut) does not conform to image type")
         }
     }
 


### PR DESCRIPTION
## What's new in this PR?

Add support of `quicktime` as movie type for `conformsToMovieType` method.
Add support of `m4a` and `mp4` as audio type for `conformsToMovieType` method.
